### PR TITLE
Fix missing dropdown icons on global Skills and MCP pages

### DIFF
--- a/crates/desktop/src/pages/settings/mcp-servers.tsx
+++ b/crates/desktop/src/pages/settings/mcp-servers.tsx
@@ -1,4 +1,9 @@
-import { ArrowPathIcon, PlusIcon } from "@heroicons/react/24/solid";
+import {
+	ArrowDownTrayIcon,
+	ArrowPathIcon,
+	PlusIcon,
+	ServerIcon,
+} from "@heroicons/react/24/solid";
 import { Button, Dropdown } from "@heroui/react";
 import { useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
@@ -115,13 +120,19 @@ export default function MCPServersPage() {
 									id="manual"
 									textValue={t("manualCreation")}
 								>
-									{t("manualCreation")}
+									<div className="flex items-center gap-2">
+										<ServerIcon className="size-4" />
+										<span>{t("manualCreation")}</span>
+									</div>
 								</Dropdown.Item>
 								<Dropdown.Item
 									id="import"
 									textValue={t("importFromJson")}
 								>
-									{t("importFromJson")}
+									<div className="flex items-center gap-2">
+										<ArrowDownTrayIcon className="size-4" />
+										<span>{t("importFromJson")}</span>
+									</div>
 								</Dropdown.Item>
 							</Dropdown.Menu>
 						</Dropdown.Popover>

--- a/crates/desktop/src/pages/settings/skills.tsx
+++ b/crates/desktop/src/pages/settings/skills.tsx
@@ -1,4 +1,9 @@
-import { ArrowPathIcon, PlusIcon } from "@heroicons/react/24/solid";
+import {
+	ArrowDownTrayIcon,
+	ArrowPathIcon,
+	CommandLineIcon,
+	PlusIcon,
+} from "@heroicons/react/24/solid";
 import { Button, Dropdown } from "@heroui/react";
 import { useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
@@ -89,13 +94,19 @@ export default function SkillsPage() {
 									id="create"
 									textValue={t("createCustomSkill")}
 								>
-									{t("createCustomSkill")}
+									<div className="flex items-center gap-2">
+										<CommandLineIcon className="size-4" />
+										<span>{t("createCustomSkill")}</span>
+									</div>
 								</Dropdown.Item>
 								<Dropdown.Item
 									id="import"
 									textValue={t("importFromFile")}
 								>
-									{t("importFromFile")}
+									<div className="flex items-center gap-2">
+										<ArrowDownTrayIcon className="size-4" />
+										<span>{t("importFromFile")}</span>
+									</div>
 								</Dropdown.Item>
 							</Dropdown.Menu>
 						</Dropdown.Popover>


### PR DESCRIPTION
## Summary
- add icons to the Global Skills dropdown actions for creating and importing skills
- add icons to the Global MCP dropdown actions for manual creation and JSON import
- align both menus with the existing icon-and-label dropdown pattern used elsewhere in the desktop UI

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced MCP Servers settings page with icons for manual creation and import options.
  * Enhanced Skills settings page with icons for creation and import options, providing clearer visual guidance for user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->