### PR TITLE
feat: cross-platform editor detection: detects editors on different OSes

### DIFF
--- a/crates/api/src/dto/integrations.rs
+++ b/crates/api/src/dto/integrations.rs
@@ -23,7 +23,10 @@ pub enum CodeEditorType {
 pub struct EditorDescriptor {
 	pub display_name: &'static str,
 	pub cli_command: &'static str,
-	pub macos_app_name: &'static str,
+	pub macos_app_names: &'static [&'static str],
+	pub windows_exe_paths: &'static [&'static str],
+	pub linux_bin_paths: &'static [&'static str],
+	pub linux_flatpak_ids: &'static [&'static str],
 }
 
 impl CodeEditorType {
@@ -32,77 +35,207 @@ impl CodeEditorType {
 			Self::VsCode => EditorDescriptor {
 				display_name: "VS Code",
 				cli_command: "code",
-				macos_app_name: "Visual Studio Code.app",
+				macos_app_names: &["Visual Studio Code.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\Programs\\Microsoft VS Code\\Code.exe",
+					"%ProgramFiles%\\Microsoft VS Code\\Code.exe",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/code",
+					"/usr/share/code/bin/code",
+					"/snap/bin/code",
+				],
+				linux_flatpak_ids: &["com.visualstudio.code"],
 			},
 			Self::VsCodeInsiders => EditorDescriptor {
 				display_name: "VS Code Insiders",
 				cli_command: "code-insiders",
-				macos_app_name: "Visual Studio Code - Insiders.app",
+				macos_app_names: &["Visual Studio Code - Insiders.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\Programs\\Microsoft VS Code Insiders\\Code - Insiders.exe",
+					"%ProgramFiles%\\Microsoft VS Code Insiders\\Code - Insiders.exe",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/code-insiders",
+					"/snap/bin/code-insiders",
+				],
+				linux_flatpak_ids: &["com.visualstudio.code.insiders"],
 			},
 			Self::Cursor => EditorDescriptor {
 				display_name: "Cursor",
 				cli_command: "cursor",
-				macos_app_name: "Cursor.app",
+				macos_app_names: &["Cursor.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\Programs\\cursor\\Cursor.exe",
+					"%LOCALAPPDATA%\\cursor\\Cursor.exe",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/cursor",
+					"/opt/Cursor/cursor",
+				],
+				linux_flatpak_ids: &[],
 			},
 			Self::Windsurf => EditorDescriptor {
 				display_name: "Windsurf",
 				cli_command: "windsurf",
-				macos_app_name: "Windsurf.app",
+				macos_app_names: &["Windsurf.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\Programs\\Windsurf\\Windsurf.exe",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/windsurf",
+					"/opt/Windsurf/windsurf",
+				],
+				linux_flatpak_ids: &[],
 			},
 			Self::Zed => EditorDescriptor {
 				display_name: "Zed",
 				cli_command: "zed",
-				macos_app_name: "Zed.app",
+				macos_app_names: &["Zed.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\Zed\\zed.exe",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/zed",
+					"/usr/local/bin/zed",
+				],
+				linux_flatpak_ids: &["dev.zed.Zed"],
 			},
 			Self::AntiGravity => EditorDescriptor {
 				display_name: "AntiGravity",
 				cli_command: "antigravity",
-				macos_app_name: "Antigravity.app",
+				macos_app_names: &["Antigravity.app"],
+				windows_exe_paths: &[],
+				linux_bin_paths: &[],
+				linux_flatpak_ids: &[],
 			},
 			Self::Trae => EditorDescriptor {
 				display_name: "Trae",
 				cli_command: "trae",
-				macos_app_name: "Trae.app",
+				macos_app_names: &["Trae.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\Programs\\Trae\\Trae.exe",
+				],
+				linux_bin_paths: &["/usr/bin/trae"],
+				linux_flatpak_ids: &[],
 			},
 			Self::SublimeText => EditorDescriptor {
 				display_name: "Sublime Text",
 				cli_command: "subl",
-				macos_app_name: "Sublime Text.app",
+				macos_app_names: &["Sublime Text.app"],
+				windows_exe_paths: &[
+					"%ProgramFiles%\\Sublime Text\\subl.exe",
+					"%ProgramFiles%\\Sublime Text 3\\subl.exe",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/subl",
+					"/opt/sublime_text/sublime_text",
+					"/snap/bin/subl",
+				],
+				linux_flatpak_ids: &["com.sublimetext.three"],
 			},
 			Self::WebStorm => EditorDescriptor {
 				display_name: "WebStorm",
 				cli_command: "webstorm",
-				macos_app_name: "WebStorm.app",
+				macos_app_names: &["WebStorm.app"],
+				windows_exe_paths: &[
+					"%ProgramFiles%\\JetBrains\\WebStorm\\bin\\webstorm64.exe",
+					"%LOCALAPPDATA%\\JetBrains\\Toolbox\\scripts\\webstorm.cmd",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/webstorm",
+					"/usr/local/bin/webstorm",
+					"/snap/bin/webstorm",
+				],
+				linux_flatpak_ids: &["com.jetbrains.WebStorm"],
 			},
 			Self::IntellijIdea => EditorDescriptor {
 				display_name: "IntelliJ IDEA",
 				cli_command: "idea",
-				macos_app_name: "IntelliJ IDEA.app",
+				macos_app_names: &[
+					"IntelliJ IDEA.app",
+					"IntelliJ IDEA CE.app",
+				],
+				windows_exe_paths: &[
+					"%ProgramFiles%\\JetBrains\\IntelliJ IDEA\\bin\\idea64.exe",
+					"%ProgramFiles%\\JetBrains\\IntelliJ IDEA Community Edition\\bin\\idea64.exe",
+					"%LOCALAPPDATA%\\JetBrains\\Toolbox\\scripts\\idea.cmd",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/idea",
+					"/usr/local/bin/idea",
+					"/snap/bin/intellij-idea-ultimate",
+					"/snap/bin/intellij-idea-community",
+				],
+				linux_flatpak_ids: &[
+					"com.jetbrains.IntelliJ-IDEA-Ultimate",
+					"com.jetbrains.IntelliJ-IDEA-Community",
+				],
 			},
 			Self::GoLand => EditorDescriptor {
 				display_name: "GoLand",
 				cli_command: "goland",
-				macos_app_name: "GoLand.app",
+				macos_app_names: &["GoLand.app"],
+				windows_exe_paths: &[
+					"%ProgramFiles%\\JetBrains\\GoLand\\bin\\goland64.exe",
+					"%LOCALAPPDATA%\\JetBrains\\Toolbox\\scripts\\goland.cmd",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/goland",
+					"/usr/local/bin/goland",
+					"/snap/bin/goland",
+				],
+				linux_flatpak_ids: &["com.jetbrains.GoLand"],
 			},
 			Self::RustRover => EditorDescriptor {
 				display_name: "RustRover",
 				cli_command: "rustrover",
-				macos_app_name: "RustRover.app",
+				macos_app_names: &["RustRover.app"],
+				windows_exe_paths: &[
+					"%ProgramFiles%\\JetBrains\\RustRover\\bin\\rustrover64.exe",
+					"%LOCALAPPDATA%\\JetBrains\\Toolbox\\scripts\\rustrover.cmd",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/rustrover",
+					"/usr/local/bin/rustrover",
+					"/snap/bin/rustrover",
+				],
+				linux_flatpak_ids: &["com.jetbrains.RustRover"],
 			},
 			Self::Fleet => EditorDescriptor {
 				display_name: "Fleet",
 				cli_command: "fleet",
-				macos_app_name: "Fleet.app",
+				macos_app_names: &["Fleet.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\JetBrains\\Toolbox\\scripts\\fleet.cmd",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/fleet",
+					"/usr/local/bin/fleet",
+				],
+				linux_flatpak_ids: &[],
 			},
 			Self::Nova => EditorDescriptor {
 				display_name: "Nova",
 				cli_command: "nova",
-				macos_app_name: "Nova.app",
+				macos_app_names: &["Nova.app"],
+				windows_exe_paths: &[],
+				linux_bin_paths: &[],
+				linux_flatpak_ids: &[],
 			},
 			Self::VsCodium => EditorDescriptor {
 				display_name: "VSCodium",
 				cli_command: "codium",
-				macos_app_name: "VSCodium.app",
+				macos_app_names: &["VSCodium.app"],
+				windows_exe_paths: &[
+					"%LOCALAPPDATA%\\Programs\\VSCodium\\VSCodium.exe",
+					"%ProgramFiles%\\VSCodium\\VSCodium.exe",
+				],
+				linux_bin_paths: &[
+					"/usr/bin/codium",
+					"/snap/bin/codium",
+				],
+				linux_flatpak_ids: &["com.vscodium.codium"],
 			},
 		}
 	}
@@ -113,10 +246,6 @@ impl CodeEditorType {
 
 	pub fn cli_command(&self) -> &'static str {
 		self.descriptor().cli_command
-	}
-
-	pub fn macos_app_name(&self) -> &'static str {
-		self.descriptor().macos_app_name
 	}
 
 	pub fn all() -> &'static [CodeEditorType] {

--- a/crates/api/src/editor_detection.rs
+++ b/crates/api/src/editor_detection.rs
@@ -1,0 +1,169 @@
+use which::which;
+
+use crate::dto::integrations::{CodeEditorType, EditorDescriptor, ToolInfoDto};
+
+impl From<&CodeEditorType> for ToolInfoDto {
+	fn from(editor: &CodeEditorType) -> Self {
+		let desc = editor.descriptor();
+		let (installed, path) = detect_editor(&desc);
+
+		Self {
+			id: serde_json::to_string(editor)
+				.unwrap_or_default()
+				.trim_matches('"')
+				.to_string(),
+			name: desc.display_name.to_string(),
+			installed,
+			path,
+		}
+	}
+}
+
+pub fn detect_any_installed_editor() -> Option<CodeEditorType> {
+	CodeEditorType::all()
+		.iter()
+		.find(|editor| detect_editor(&editor.descriptor()).0)
+		.cloned()
+}
+
+fn detect_editor(desc: &EditorDescriptor) -> (bool, Option<String>) {
+	if let Some(path) = detect_platform_path(desc) {
+		return (true, Some(path));
+	}
+
+	if let Ok(p) = which(desc.cli_command) {
+		return (true, Some(p.to_string_lossy().to_string()));
+	}
+
+	(false, None)
+}
+
+#[cfg(target_os = "macos")]
+fn detect_platform_path(desc: &EditorDescriptor) -> Option<String> {
+	use std::path::PathBuf;
+
+	let search_dirs = [
+		PathBuf::from("/Applications"),
+		dirs::home_dir()
+			.map(|h| h.join("Applications"))
+			.unwrap_or_else(|| PathBuf::from("/Applications")),
+	];
+
+	for app_name in desc.macos_app_names {
+		for dir in &search_dirs {
+			let app_path = dir.join(app_name);
+			if app_path.exists() {
+				return Some(app_path.to_string_lossy().to_string());
+			}
+		}
+	}
+	None
+}
+
+#[cfg(target_os = "windows")]
+fn detect_platform_path(desc: &EditorDescriptor) -> Option<String> {
+	for template in desc.windows_exe_paths {
+		let expanded = expand_env_var_placeholders(template, |name| {
+			std::env::var(name).ok()
+		});
+		let path = std::path::Path::new(&expanded);
+		if path.exists() {
+			return Some(expanded);
+		}
+	}
+	None
+}
+
+#[cfg(target_os = "linux")]
+fn detect_platform_path(desc: &EditorDescriptor) -> Option<String> {
+	for bin_path in desc.linux_bin_paths {
+		if std::path::Path::new(bin_path).exists() {
+			return Some((*bin_path).to_string());
+		}
+	}
+
+	for app_id in desc.linux_flatpak_ids {
+		let ok = std::process::Command::new("flatpak")
+			.args(["info", app_id])
+			.stdout(std::process::Stdio::null())
+			.stderr(std::process::Stdio::null())
+			.status()
+			.map(|s| s.success())
+			.unwrap_or(false);
+		if ok {
+			return Some(format!("flatpak::{}", app_id));
+		}
+	}
+
+	None
+}
+
+#[cfg(not(any(
+	target_os = "macos",
+	target_os = "windows",
+	target_os = "linux"
+)))]
+fn detect_platform_path(_desc: &EditorDescriptor) -> Option<String> {
+	None
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn expand_env_var_placeholders(
+	template: &str,
+	resolve: impl Fn(&str) -> Option<String>,
+) -> String {
+	let mut result = template.to_string();
+	for var_name in [
+		"LOCALAPPDATA",
+		"APPDATA",
+		"ProgramFiles",
+		"ProgramFiles(x86)",
+		"USERPROFILE",
+		"SystemDrive",
+	] {
+		let placeholder = format!("%{}%", var_name);
+		if result.contains(&placeholder) {
+			if let Some(value) = resolve(var_name) {
+				result = result.replace(&placeholder, &value);
+			}
+		}
+	}
+	result
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_all_editors_have_cli_command() {
+		for editor in CodeEditorType::all() {
+			assert!(!editor.descriptor().cli_command.is_empty());
+		}
+	}
+
+	#[test]
+	fn test_all_editors_have_display_name() {
+		for editor in CodeEditorType::all() {
+			assert!(!editor.descriptor().display_name.is_empty());
+		}
+	}
+
+	#[test]
+	fn test_expand_env_var_placeholders() {
+		let expanded = expand_env_var_placeholders(
+			"%LOCALAPPDATA%\\Programs\\Code\\Code.exe",
+			|name| match name {
+				"LOCALAPPDATA" => Some("C:\\Users\\test\\AppData\\Local".to_string()),
+				_ => None,
+			},
+		);
+		assert_eq!(expanded, "C:\\Users\\test\\AppData\\Local\\Programs\\Code\\Code.exe");
+	}
+
+	#[test]
+	fn test_expand_unknown_var_left_as_is() {
+		let expanded = expand_env_var_placeholders("%UNKNOWN%\\something", |_| None);
+		assert_eq!(expanded, "%UNKNOWN%\\something");
+	}
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate rocket;
 
 pub mod dto;
+pub mod editor_detection;
 pub mod error;
 pub mod extractors;
 pub mod routes;

--- a/crates/api/src/routes/integrations.rs
+++ b/crates/api/src/routes/integrations.rs
@@ -1,46 +1,15 @@
-use std::path::Path;
 use std::process::Command;
 
 use rocket::serde::json::Json;
-use which::which;
 
 use crate::dto::integrations::{
 	CodeEditorType, OpenWithEditorRequest, ToolInfoDto, ToolPreferencesDto,
 };
 
-fn get_code_editor_info(editor: &CodeEditorType) -> ToolInfoDto {
-	let desc = editor.descriptor();
-
-	let app_path = Path::new("/Applications").join(desc.macos_app_name);
-	let from_app = app_path.exists();
-	let cli_path = which(desc.cli_command)
-		.ok()
-		.map(|p| p.to_string_lossy().to_string());
-
-	let installed = from_app || cli_path.is_some();
-	let path = if from_app {
-		Some(app_path.to_string_lossy().to_string())
-	} else {
-		cli_path
-	};
-
-	ToolInfoDto {
-		id: serde_json::to_string(editor)
-			.unwrap_or_default()
-			.trim_matches('"')
-			.to_string(),
-		name: desc.display_name.to_string(),
-		installed,
-		path,
-	}
-}
-
 #[get("/integrations/code-editors")]
 pub fn list_code_editors() -> Json<Vec<ToolInfoDto>> {
-	let editors: Vec<ToolInfoDto> = CodeEditorType::all()
-		.iter()
-		.map(get_code_editor_info)
-		.collect();
+	let editors: Vec<ToolInfoDto> =
+		CodeEditorType::all().iter().map(ToolInfoDto::from).collect();
 	Json(editors)
 }
 

--- a/crates/api/src/routes/skills.rs
+++ b/crates/api/src/routes/skills.rs
@@ -7,7 +7,6 @@ use aghub_core::{
 use rocket::http::Status;
 use rocket::response::status::NoContent;
 use rocket::serde::json::Json;
-use which::which;
 
 use crate::{
 	dto::integrations::{
@@ -50,14 +49,7 @@ fn get_skill_root(path: std::path::PathBuf) -> std::path::PathBuf {
 }
 
 fn detect_available_editor() -> Option<CodeEditorType> {
-	CodeEditorType::all()
-		.iter()
-		.find(|editor| {
-			let app_path = std::path::Path::new("/Applications")
-				.join(editor.macos_app_name());
-			app_path.exists() || which(editor.cli_command()).is_ok()
-		})
-		.cloned()
+	crate::editor_detection::detect_any_installed_editor()
 }
 
 fn build_skill_tree_node(

--- a/crates/desktop/src-tauri/tauri.conf.json
+++ b/crates/desktop/src-tauri/tauri.conf.json
@@ -15,6 +15,8 @@
 				"title": "aghub",
 				"width": 1280,
 				"height": 800,
+				"minWidth": 1024,
+				"minHeight": 600,
 				"decorations": true,
 				"hiddenTitle": true,
 				"titleBarStyle": "Overlay",


### PR DESCRIPTION
This commit will detect editors from different OSes dynamically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved editor detection across macOS, Windows, and Linux (including Flatpak) with automatic discovery of installed code editors.
* **Chores**
  * Desktop app window now enforces minimum size (1024×600) for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->