### PR TITLE
Group new user guide actions on About settings

### DIFF
--- a/crates/desktop/src/components/skill-detail-helpers.ts
+++ b/crates/desktop/src/components/skill-detail-helpers.ts
@@ -1,6 +1,9 @@
 import type { AgentInfo } from "../lib/api";
-import type { SkillResponse, SkillTreeNodeResponse } from "../lib/api-types";
-import { ConfigSource } from "../lib/api-types";
+import type {
+	ConfigSource,
+	SkillResponse,
+	SkillTreeNodeResponse,
+} from "../lib/api-types";
 import { sortAgents } from "../lib/utils";
 
 export interface LocationInstallation {

--- a/crates/desktop/src/pages/settings/application-panel.tsx
+++ b/crates/desktop/src/pages/settings/application-panel.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Button, Card, toast } from "@heroui/react";
+import { Avatar, Button, ButtonGroup, Card, toast } from "@heroui/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { getName, getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -190,10 +190,12 @@ export default function ApplicationPanel() {
 								{t("onboardingDescription")}
 							</span>
 						</div>
-						<div className="flex flex-wrap justify-end gap-2">
+						<ButtonGroup
+							variant="secondary"
+							size="sm"
+							className="flex-wrap justify-end"
+						>
 							<Button
-								variant="secondary"
-								size="sm"
 								onPress={() =>
 									dispatchOnboardingCommand({
 										type: "show-welcome",
@@ -203,8 +205,6 @@ export default function ApplicationPanel() {
 								{t("showWelcome")}
 							</Button>
 							<Button
-								variant="secondary"
-								size="sm"
 								onPress={() =>
 									dispatchOnboardingCommand({
 										type: "start-tour",
@@ -215,8 +215,6 @@ export default function ApplicationPanel() {
 								{t("replayAppTour")}
 							</Button>
 							<Button
-								variant="secondary"
-								size="sm"
 								onPress={() =>
 									dispatchOnboardingCommand({
 										type: "start-tour",
@@ -226,7 +224,7 @@ export default function ApplicationPanel() {
 							>
 								{t("replayProjectTour")}
 							</Button>
-						</div>
+						</ButtonGroup>
 					</div>
 				</Card.Content>
 			</Card>


### PR DESCRIPTION
## Summary
- replace the three standalone New User Guide action buttons in Settings > About with a single grouped control
- keep the existing onboarding actions and handlers unchanged
- include the lint-driven type-only import cleanup needed to keep the desktop checks passing

## Verification
- bun run build
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal import organization in helper modules.

* **Style**
  * Refined onboarding action controls layout in the application settings panel for enhanced visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->