### PR TITLE
Fix GitHub skill installs to prefer primary agent paths

### DIFF
--- a/crates/api/src/routes/skills.rs
+++ b/crates/api/src/routes/skills.rs
@@ -291,14 +291,15 @@ fn install_git_skill_to_dir(
 	Ok(skill.name)
 }
 
+type GitInstallAgentGroup = Vec<(String, AgentType)>;
+type GitInstallGroups = HashMap<std::path::PathBuf, GitInstallAgentGroup>;
+type GitInstallInvalidAgent = (String, Option<AgentType>, String);
+
 fn build_git_install_groups(
 	agents: &[String],
 	resource_scope: ResourceScope,
 	project_root: Option<&std::path::PathBuf>,
-) -> (
-	HashMap<std::path::PathBuf, Vec<(String, AgentType)>>,
-	Vec<(String, Option<AgentType>, String)>,
-) {
+) -> (GitInstallGroups, Vec<GitInstallInvalidAgent>) {
 	let mut groups = HashMap::new();
 	let mut invalid = Vec::new();
 


### PR DESCRIPTION
## Summary
- group GitHub skill installs by each agent's primary target skills path instead of loading and writing per agent
- copy each imported skill once per target directory and treat repeated installs to the same directory as success
- add regression tests covering primary-path grouping, duplicate install handling, and `reconcile_skill` using OpenCode's primary project path

## Testing
- `just fmt`
- `cargo test -q -p aghub-api --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster, grouped skill installations that install once per target location for multiple agents.
  * Idempotent installs: existing skill copies are not duplicated on repeat installs.
  * Clearer reporting when an agent cannot accept a skill in the selected scope.
* **Tests**
  * Added unit tests covering grouping, idempotence, and path reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->