### PR TITLE
fix(core): correct CRLF byte offset in read_existing_body

### DIFF
--- a/crates/core/src/manager/skill.rs
+++ b/crates/core/src/manager/skill.rs
@@ -29,23 +29,23 @@ fn read_existing_body(path: &Path) -> Result<Option<String>> {
 	};
 
 	let mut in_frontmatter = false;
-	let mut body_start = None;
+	let mut byte_pos: usize = 0;
 
-	for (i, line) in content.lines().enumerate() {
-		if line.trim() == "---" {
+	for segment in content.split('\n') {
+		// segment may end with '\r' on CRLF files; strip it only for comparison.
+		let segment_byte_len = segment.len() + 1; // +1 for the '\n' we split on
+		if segment.trim_end_matches('\r').trim() == "---" {
 			if !in_frontmatter {
 				in_frontmatter = true;
 			} else {
-				// Found closing ---, body starts after this line
-				let byte_offset: usize =
-					content.lines().take(i + 1).map(|l| l.len() + 1).sum();
-				body_start = Some(byte_offset.min(content.len()));
-				break;
+				let offset = (byte_pos + segment_byte_len).min(content.len());
+				return Ok(Some(content[offset..].to_string()));
 			}
 		}
+		byte_pos += segment_byte_len;
 	}
 
-	Ok(body_start.map(|start| content[start..].to_string()))
+	Ok(None)
 }
 
 /// Remove a skill's file or directory from disk.


### PR DESCRIPTION
## Summary

- `read_existing_body` used `str::lines()` + `l.len() + 1` to compute the byte offset after the closing `---` marker, assuming LF-only line endings
- On CRLF files, each line is under-counted by 1 byte, so the slice lands inside the `---` line and the extracted body starts with `--` garbage
- Fix: switch to `split('\n')` which preserves `\r` in each segment, making `segment.len() + 1` the correct byte cost for both LF and CRLF

## Test plan

- [x] Added `test_read_existing_body_crlf_no_garbage` — writes raw CRLF bytes and asserts no leftover `---` chars in the extracted body
- [x] Test fails on the old code, passes on the fix
- [x] All existing tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with files using CRLF line endings (common on Windows systems).
  * Fixed body content extraction to correctly identify frontmatter delimiters regardless of line ending format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->