### PR TITLE
Refactor core skill updates to reuse skill parser

### DIFF
--- a/crates/core/src/manager/skill.rs
+++ b/crates/core/src/manager/skill.rs
@@ -17,37 +17,6 @@ fn resolve_source_path(sp: &str) -> PathBuf {
 	}
 }
 
-/// Read the body (everything after the closing `---`) from an existing SKILL.md.
-/// Returns Err on I/O failure, Ok(None) if file doesn't exist or has no body.
-fn read_existing_body(path: &Path) -> Result<Option<String>> {
-	let content = match std::fs::read_to_string(path) {
-		Ok(c) => c,
-		Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-			return Ok(None);
-		}
-		Err(e) => return Err(e.into()),
-	};
-
-	let mut in_frontmatter = false;
-	let mut body_start = None;
-
-	for (i, line) in content.lines().enumerate() {
-		if line.trim() == "---" {
-			if !in_frontmatter {
-				in_frontmatter = true;
-			} else {
-				// Found closing ---, body starts after this line
-				let byte_offset: usize =
-					content.lines().take(i + 1).map(|l| l.len() + 1).sum();
-				body_start = Some(byte_offset.min(content.len()));
-				break;
-			}
-		}
-	}
-
-	Ok(body_start.map(|start| content[start..].to_string()))
-}
-
 /// Remove a skill's file or directory from disk.
 ///
 /// Handles three cases:
@@ -166,7 +135,16 @@ impl ConfigManager {
 
 		if let Some(path) = file_path {
 			// Read existing body before any filesystem changes
-			let existing_body = read_existing_body(&path)?;
+			let existing_body = match skill::parser::parse(&path) {
+				Ok(existing) => Some(existing.content),
+				Err(skill::SkillError::NotFound(_)) => None,
+				Err(e) => {
+					return Err(ConfigError::InvalidConfig(format!(
+						"Failed to parse existing skill '{}': {e}",
+						path.display()
+					)));
+				}
+			};
 
 			let mut final_file_path = path.clone();
 
@@ -322,13 +300,15 @@ fn serialize_frontmatter(skill: &Skill) -> String {
 		"name".to_string(),
 		serde_yaml::Value::String(skill.name.clone()),
 	);
-	if let Some(desc) = &skill.description {
-		let single_line = desc.replace('\n', " ");
-		map.insert(
-			"description".to_string(),
-			serde_yaml::Value::String(single_line),
-		);
-	}
+	let description = skill
+		.description
+		.as_deref()
+		.unwrap_or("")
+		.replace('\n', " ");
+	map.insert(
+		"description".to_string(),
+		serde_yaml::Value::String(description),
+	);
 	if let Some(author) = &skill.author {
 		map.insert(
 			"author".to_string(),
@@ -392,6 +372,15 @@ mod tests {
 	}
 
 	#[test]
+	fn test_format_skill_stays_parseable_by_skill_crate() {
+		let skill = Skill::new("test-skill");
+		let output = format_skill(&skill, None);
+		let parsed = skill::parser::parse_skill_md(&output).unwrap();
+		assert_eq!(parsed.name, "test-skill");
+		assert_eq!(parsed.description, "");
+	}
+
+	#[test]
 	fn test_format_skill_quotes_colon_in_description() {
 		let mut skill = Skill::new("test");
 		skill.description = Some("Source: https://example.com".to_string());
@@ -424,28 +413,5 @@ mod tests {
 		.expect("Should produce valid YAML");
 		assert_eq!(reparsed["version"], "123");
 		assert_eq!(reparsed["author"], "true");
-	}
-
-	#[test]
-	fn test_read_existing_body_extracts_correctly() {
-		let tmp = tempfile::tempdir().unwrap();
-		let path = tmp.path().join("SKILL.md");
-		std::fs::write(
-			&path,
-			"---\nname: test\ndescription: desc\n---\n\n\
-			 # Test\n\nBody content here.\n",
-		)
-		.unwrap();
-		let body = read_existing_body(&path).unwrap().unwrap();
-		assert!(body.contains("# Test"));
-		assert!(body.contains("Body content here."));
-	}
-
-	#[test]
-	fn test_read_existing_body_missing_file_returns_none() {
-		let tmp = tempfile::tempdir().unwrap();
-		let path = tmp.path().join("nonexistent.md");
-		let result = read_existing_body(&path).unwrap();
-		assert!(result.is_none());
 	}
 }


### PR DESCRIPTION
## Summary
- replace the custom `SKILL.md` body extraction in `crates/core/src/manager/skill.rs` with `skill::parser::parse`
- remove the redundant local parsing helper and its tests from `core`
- always serialize a `description` field so generated `SKILL.md` files remain parseable by the shared skill parser
- add a regression test covering round-trip parsing through the skill crate

## Testing
- `cargo test -p aghub-core manager::skill -- --nocapture`
- `cargo test -p aghub-core test_source_path_update_targets_original_directory -- --nocapture`
- `cargo test -p aghub-core test_rename_skill_migrates_sanitized_directory -- --nocapture`