### PR TITLE
fix: remove empty onSuccess causing tanstack query not invlidate content

### DIFF
--- a/crates/desktop/src/pages/settings/integrations-panel.tsx
+++ b/crates/desktop/src/pages/settings/integrations-panel.tsx
@@ -91,7 +91,6 @@ export default function IntegrationsPanel() {
 				setDeleteTarget(null);
 			},
 		}),
-		onSuccess: () => {},
 		onError: (error) => {
 			console.error("Failed to delete credential:", error);
 			toast.danger(


### PR DESCRIPTION
This MR removes the empty onSuccess override causing deleteMutation does not invlidate conent after delete success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined credential deletion logic by consolidating success handling, improving code maintainability without affecting user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->