### PR TITLE
feat(inference provider support): [1] import agent credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ version = "0.1.2"
 dependencies = [
  "aghub-markdown",
  "dirs",
+ "json5",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -247,7 +248,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -258,7 +259,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -967,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1363,7 +1364,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1568,7 +1569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3313,7 +3314,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3575,7 +3576,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3635,7 +3636,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3716,6 +3717,17 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -4157,7 +4169,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4569,6 +4581,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -5078,7 +5133,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5116,9 +5171,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5667,7 +5722,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5725,7 +5780,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6276,7 +6331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7036,10 +7091,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7590,6 +7645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7597,7 +7658,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8154,7 +8215,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8344,15 +8405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ predicates = "3.1"
 
 # YAML parsing
 serde_yaml = "0.9"
+json5 = "0.4"
 
 # TOML parsing
 toml = "1.0"

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+json5 = { workspace = true }
 toml = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }

--- a/crates/agents/src/agents/amp.rs
+++ b/crates/agents/src/agents/amp.rs
@@ -61,6 +61,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "amp",
 	validate_args: &["--version"],
 	project_markers: &[".amp"],

--- a/crates/agents/src/agents/amp.rs
+++ b/crates/agents/src/agents/amp.rs
@@ -61,7 +61,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "amp",
 	validate_args: &["--version"],
 	project_markers: &[".amp"],

--- a/crates/agents/src/agents/antigravity.rs
+++ b/crates/agents/src/agents/antigravity.rs
@@ -57,7 +57,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "antigravity",
 	validate_args: &["--version"],
 	project_markers: &[".gemini/antigravity"],

--- a/crates/agents/src/agents/antigravity.rs
+++ b/crates/agents/src/agents/antigravity.rs
@@ -57,6 +57,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "antigravity",
 	validate_args: &["--version"],
 	project_markers: &[".gemini/antigravity"],

--- a/crates/agents/src/agents/augmentcode.rs
+++ b/crates/agents/src/agents/augmentcode.rs
@@ -45,7 +45,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "augmentcode",
 	validate_args: &["--version"],
 	project_markers: &[".augmentcode"],

--- a/crates/agents/src/agents/augmentcode.rs
+++ b/crates/agents/src/agents/augmentcode.rs
@@ -45,6 +45,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "augmentcode",
 	validate_args: &["--version"],
 	project_markers: &[".augmentcode"],

--- a/crates/agents/src/agents/claude.rs
+++ b/crates/agents/src/agents/claude.rs
@@ -156,7 +156,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents,
 	save_sub_agents,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "claude",
 	validate_args: &["--version"],
 	project_markers: &[".claude", ".mcp.json"],

--- a/crates/agents/src/agents/claude.rs
+++ b/crates/agents/src/agents/claude.rs
@@ -156,6 +156,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents,
 	save_sub_agents,
+	import_credientials: import_credientials_noop,
 	cli_name: "claude",
 	validate_args: &["--version"],
 	project_markers: &[".claude", ".mcp.json"],

--- a/crates/agents/src/agents/cline.rs
+++ b/crates/agents/src/agents/cline.rs
@@ -58,6 +58,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "cline",
 	validate_args: &["--version"],
 	project_markers: &[".cline"],

--- a/crates/agents/src/agents/cline.rs
+++ b/crates/agents/src/agents/cline.rs
@@ -58,7 +58,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "cline",
 	validate_args: &["--version"],
 	project_markers: &[".cline"],

--- a/crates/agents/src/agents/codex/credentials.rs
+++ b/crates/agents/src/agents/codex/credentials.rs
@@ -1,0 +1,140 @@
+use super::mcp;
+use crate::errors::{ConfigError, Result};
+use crate::models::{Credential, CredentialType, ResourceScope};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const BUILTIN_PROVIDER_IDS: [&str; 3] = ["openai", "ollama", "lmstudio"];
+
+#[derive(Debug, Default, Deserialize)]
+struct CodexConfig {
+	profile: Option<String>,
+	#[serde(default)]
+	model_providers: HashMap<String, CodexProvider>,
+	#[serde(default)]
+	profiles: HashMap<String, CodexProfile>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CodexProfile {
+	#[serde(default)]
+	model_providers: HashMap<String, CodexProvider>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+struct CodexProvider {
+	name: Option<String>,
+	base_url: Option<String>,
+	env_key: Option<String>,
+}
+
+impl CodexProvider {
+	fn merge_from(&mut self, other: &Self) {
+		if other.name.is_some() {
+			self.name = other.name.clone();
+		}
+		if other.base_url.is_some() {
+			self.base_url = other.base_url.clone();
+		}
+		if other.env_key.is_some() {
+			self.env_key = other.env_key.clone();
+		}
+	}
+}
+
+pub(super) fn import_credientials(
+	project_root: Option<&Path>,
+	scope: ResourceScope,
+) -> Result<Vec<Credential>> {
+	let Some(path) = config_path(project_root, scope)? else {
+		return Ok(Vec::new());
+	};
+
+	let content = match fs::read_to_string(&path) {
+		Ok(content) => content,
+		Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+			return Ok(Vec::new())
+		}
+		Err(e) => return Err(e.into()),
+	};
+
+	let config: CodexConfig = toml::from_str(&content).map_err(|e| {
+		ConfigError::InvalidConfig(format!(
+			"Failed to parse Codex config TOML: {e}"
+		))
+	})?;
+
+	let mut credentials = Vec::new();
+	for (id, provider) in merged_providers(config) {
+		if BUILTIN_PROVIDER_IDS.contains(&id.as_str()) {
+			continue;
+		}
+
+		let base = clean_string(provider.base_url);
+		if base.is_none() {
+			continue;
+		}
+
+		let mut credential = Credential::new(
+			clean_string(provider.name).unwrap_or(id),
+			CredentialType::Openai,
+		);
+		credential.base = base;
+		credential.key = resolve_env_key(provider.env_key);
+		credentials.push(credential);
+	}
+
+	credentials.sort_by(|a, b| a.name.cmp(&b.name));
+	Ok(credentials)
+}
+
+fn config_path(
+	project_root: Option<&Path>,
+	scope: ResourceScope,
+) -> Result<Option<PathBuf>> {
+	match scope {
+		ResourceScope::GlobalOnly => Ok(mcp::global_path()),
+		ResourceScope::ProjectOnly => {
+			Ok(project_root.and_then(mcp::project_path))
+		}
+		ResourceScope::Both => Err(ConfigError::InvalidConfig(
+			"Credential path unavailable for Both scope".to_string(),
+		)),
+	}
+}
+
+fn merged_providers(config: CodexConfig) -> HashMap<String, CodexProvider> {
+	let mut providers = config.model_providers;
+
+	if let Some(profile_name) = config.profile.as_deref() {
+		if let Some(profile) = config.profiles.get(profile_name) {
+			for (provider_id, profile_provider) in &profile.model_providers {
+				let provider =
+					providers.entry(provider_id.clone()).or_default();
+				provider.merge_from(profile_provider);
+			}
+		}
+	}
+
+	providers
+}
+
+fn clean_string(value: Option<String>) -> Option<String> {
+	value.and_then(|value| {
+		let trimmed = value.trim();
+		if trimmed.is_empty() {
+			None
+		} else {
+			Some(trimmed.to_string())
+		}
+	})
+}
+
+fn resolve_env_key(env_key: Option<String>) -> Option<String> {
+	let env_key = clean_string(env_key)?;
+	std::env::var(&env_key)
+		.ok()
+		.and_then(|value| clean_string(Some(value)))
+}

--- a/crates/agents/src/agents/codex/credentials.rs
+++ b/crates/agents/src/agents/codex/credentials.rs
@@ -44,7 +44,7 @@ impl CodexProvider {
 	}
 }
 
-pub(super) fn import_credientials(
+pub(super) fn import_credentials(
 	project_root: Option<&Path>,
 	scope: ResourceScope,
 ) -> Result<Vec<Credential>> {

--- a/crates/agents/src/agents/codex/mod.rs
+++ b/crates/agents/src/agents/codex/mod.rs
@@ -79,7 +79,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: sub_agent::load,
 	save_sub_agents: sub_agent::save,
-	import_credientials: credentials::import_credientials,
+	import_credentials: credentials::import_credentials,
 	cli_name: "codex",
 	validate_args: &["--version"],
 	project_markers: &[".codex"],

--- a/crates/agents/src/agents/codex/mod.rs
+++ b/crates/agents/src/agents/codex/mod.rs
@@ -1,3 +1,4 @@
+mod credentials;
 mod mcp;
 mod sub_agent;
 
@@ -78,6 +79,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: sub_agent::load,
 	save_sub_agents: sub_agent::save,
+	import_credientials: credentials::import_credientials,
 	cli_name: "codex",
 	validate_args: &["--version"],
 	project_markers: &[".codex"],

--- a/crates/agents/src/agents/copilot.rs
+++ b/crates/agents/src/agents/copilot.rs
@@ -59,6 +59,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "code",
 	validate_args: &["--version"],
 	project_markers: &[".vscode"],

--- a/crates/agents/src/agents/copilot.rs
+++ b/crates/agents/src/agents/copilot.rs
@@ -59,7 +59,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "code",
 	validate_args: &["--version"],
 	project_markers: &[".vscode"],

--- a/crates/agents/src/agents/cursor.rs
+++ b/crates/agents/src/agents/cursor.rs
@@ -79,6 +79,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "cursor",
 	validate_args: &["--version"],
 	project_markers: &[".cursor"],

--- a/crates/agents/src/agents/factory.rs
+++ b/crates/agents/src/agents/factory.rs
@@ -56,7 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "factory",
 	validate_args: &["--version"],
 	project_markers: &[".factory"],

--- a/crates/agents/src/agents/factory.rs
+++ b/crates/agents/src/agents/factory.rs
@@ -56,6 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "factory",
 	validate_args: &["--version"],
 	project_markers: &[".factory"],

--- a/crates/agents/src/agents/gemini.rs
+++ b/crates/agents/src/agents/gemini.rs
@@ -57,6 +57,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "gemini",
 	validate_args: &["--version"],
 	project_markers: &[".gemini"],

--- a/crates/agents/src/agents/gemini.rs
+++ b/crates/agents/src/agents/gemini.rs
@@ -57,7 +57,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "gemini",
 	validate_args: &["--version"],
 	project_markers: &[".gemini"],

--- a/crates/agents/src/agents/jetbrains_ai.rs
+++ b/crates/agents/src/agents/jetbrains_ai.rs
@@ -45,7 +45,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "jetbrains",
 	validate_args: &["--version"],
 	project_markers: &[".jetbrains-ai"],

--- a/crates/agents/src/agents/jetbrains_ai.rs
+++ b/crates/agents/src/agents/jetbrains_ai.rs
@@ -45,6 +45,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "jetbrains",
 	validate_args: &["--version"],
 	project_markers: &[".jetbrains-ai"],

--- a/crates/agents/src/agents/kilocode.rs
+++ b/crates/agents/src/agents/kilocode.rs
@@ -56,6 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "kilocode",
 	validate_args: &["--version"],
 	project_markers: &[".kilocode"],

--- a/crates/agents/src/agents/kilocode.rs
+++ b/crates/agents/src/agents/kilocode.rs
@@ -56,7 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "kilocode",
 	validate_args: &["--version"],
 	project_markers: &[".kilocode"],

--- a/crates/agents/src/agents/kimi.rs
+++ b/crates/agents/src/agents/kimi.rs
@@ -57,7 +57,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "kimi",
 	validate_args: &["--version"],
 	project_markers: &[".kimi"],

--- a/crates/agents/src/agents/kimi.rs
+++ b/crates/agents/src/agents/kimi.rs
@@ -57,6 +57,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "kimi",
 	validate_args: &["--version"],
 	project_markers: &[".kimi"],

--- a/crates/agents/src/agents/kiro.rs
+++ b/crates/agents/src/agents/kiro.rs
@@ -58,6 +58,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "kiro",
 	validate_args: &["--version"],
 	project_markers: &[".kiro"],

--- a/crates/agents/src/agents/kiro.rs
+++ b/crates/agents/src/agents/kiro.rs
@@ -58,7 +58,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "kiro",
 	validate_args: &["--version"],
 	project_markers: &[".kiro"],

--- a/crates/agents/src/agents/mistral.rs
+++ b/crates/agents/src/agents/mistral.rs
@@ -56,6 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "mistral",
 	validate_args: &["--version"],
 	project_markers: &[".vibe"],

--- a/crates/agents/src/agents/mistral.rs
+++ b/crates/agents/src/agents/mistral.rs
@@ -56,7 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "mistral",
 	validate_args: &["--version"],
 	project_markers: &[".vibe"],

--- a/crates/agents/src/agents/openclaw.rs
+++ b/crates/agents/src/agents/openclaw.rs
@@ -123,6 +123,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "openclaw",
 	validate_args: &["--version"],
 	project_markers: &[".openclaw"],

--- a/crates/agents/src/agents/openclaw.rs
+++ b/crates/agents/src/agents/openclaw.rs
@@ -123,7 +123,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "openclaw",
 	validate_args: &["--version"],
 	project_markers: &[".openclaw"],

--- a/crates/agents/src/agents/opencode.rs
+++ b/crates/agents/src/agents/opencode.rs
@@ -1,6 +1,31 @@
 use crate::descriptor::*;
+use crate::errors::ConfigError;
+use crate::models::{Credential, CredentialType};
 use crate::sub_agents::{load_scoped_sub_agents, save_scoped_sub_agents};
+use std::collections::HashMap;
+use std::fs;
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct OpenCodeConfig {
+	#[serde(default)]
+	provider: HashMap<String, OpenCodeProvider>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct OpenCodeProvider {
+	npm: Option<String>,
+	options: Option<OpenCodeProviderOptions>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct OpenCodeProviderOptions {
+	#[serde(rename = "baseURL")]
+	base_url: Option<String>,
+	endpoint: Option<String>,
+	#[serde(rename = "apiKey")]
+	api_key: Option<String>,
+}
 
 fn mcp_global_path() -> Option<PathBuf> {
 	home_dir().map(|home| home.join(".config/opencode/opencode.json"))
@@ -97,6 +122,234 @@ fn save_sub_agents(
 	)
 }
 
+fn import_credientials(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+) -> crate::Result<Vec<Credential>> {
+	let providers = load_provider_config(project_root, scope)?;
+	let auth_entries = load_auth_keys()?;
+
+	let mut credentials = HashMap::new();
+
+	for (provider_id, provider) in &providers {
+		let mut credential = Credential::new(
+			provider_id.clone(),
+			infer_provider_type(provider_id, Some(provider)),
+		);
+		credential.base = provider_base(provider);
+		credential.key = provider_config_key(provider);
+		if credential.base.is_some() || credential.key.is_some() {
+			credentials.insert(provider_id.clone(), credential);
+		}
+	}
+
+	for (provider_id, key) in auth_entries {
+		let provider = providers.get(&provider_id);
+		let mut credential =
+			credentials.remove(&provider_id).unwrap_or_else(|| {
+				Credential::new(
+					provider_id.clone(),
+					infer_provider_type(&provider_id, provider),
+				)
+			});
+		if credential.base.is_none() {
+			credential.base = provider.and_then(provider_base);
+		}
+		credential.key = Some(key);
+		credentials.insert(provider_id, credential);
+	}
+
+	let mut result: Vec<Credential> = credentials.into_values().collect();
+	result.sort_by(|a, b| a.name.cmp(&b.name));
+	Ok(result)
+}
+
+fn load_provider_config(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+) -> crate::Result<HashMap<String, OpenCodeProvider>> {
+	let mut providers = HashMap::new();
+
+	for path in provider_config_paths(project_root, scope)? {
+		let content = match fs::read_to_string(&path) {
+			Ok(content) => content,
+			Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+			Err(e) => return Err(e.into()),
+		};
+		let config: OpenCodeConfig =
+			serde_json::from_str(&content).map_err(|e| {
+				ConfigError::InvalidConfig(format!(
+					"Failed to parse OpenCode config {}: {e}",
+					path.display()
+				))
+			})?;
+		providers.extend(config.provider);
+	}
+
+	Ok(providers)
+}
+
+fn provider_config_paths(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+) -> crate::Result<Vec<PathBuf>> {
+	match scope {
+		crate::ResourceScope::GlobalOnly => {
+			Ok(mcp_global_path().into_iter().collect())
+		}
+		crate::ResourceScope::ProjectOnly => {
+			let Some(root) = project_root else {
+				return Ok(Vec::new());
+			};
+			let mut paths = Vec::new();
+			if let Some(path) = mcp_project_path(root) {
+				paths.push(path);
+			}
+			paths.push(root.join("opencode.json"));
+			Ok(paths)
+		}
+		crate::ResourceScope::Both => Err(ConfigError::InvalidConfig(
+			"Credential path unavailable for Both scope".to_string(),
+		)),
+	}
+}
+
+fn load_auth_keys() -> crate::Result<HashMap<String, String>> {
+	let mut auth = HashMap::new();
+
+	for path in auth_path_candidates() {
+		let content = match fs::read_to_string(&path) {
+			Ok(content) => content,
+			Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+			Err(e) => return Err(e.into()),
+		};
+		let entries: HashMap<String, serde_json::Value> =
+			serde_json::from_str(&content).map_err(|e| {
+				ConfigError::InvalidConfig(format!(
+					"Failed to parse OpenCode auth {}: {e}",
+					path.display()
+				))
+			})?;
+		for (provider_id, entry) in entries {
+			if let Some(key) = auth_key_from_entry(&entry) {
+				auth.insert(provider_id, key);
+			}
+		}
+	}
+
+	Ok(auth)
+}
+
+fn auth_path_candidates() -> Vec<PathBuf> {
+	let mut paths = Vec::new();
+	if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME") {
+		paths.push(PathBuf::from(xdg_data_home).join("opencode/auth.json"));
+	}
+
+	let Some(home) = home_dir() else {
+		return paths;
+	};
+
+	paths.push(home.join(".local/share/opencode/auth.json"));
+	paths.push(home.join("Library/Application Support/opencode/auth.json"));
+	paths
+}
+
+fn auth_key_from_entry(entry: &serde_json::Value) -> Option<String> {
+	let key = match entry.get("type").and_then(|value| value.as_str()) {
+		Some("api") => entry.get("key").and_then(|value| value.as_str()),
+		Some("oauth") => entry.get("access").and_then(|value| value.as_str()),
+		Some("wellknown") => {
+			entry.get("token").and_then(|value| value.as_str())
+		}
+		_ => None,
+	}?;
+	clean_string(Some(key.to_string()))
+}
+
+fn infer_provider_type(
+	provider_id: &str,
+	provider: Option<&OpenCodeProvider>,
+) -> CredentialType {
+	if provider_id.eq_ignore_ascii_case("anthropic") {
+		return CredentialType::Anthropic;
+	}
+
+	if let Some(npm) = provider.and_then(|provider| provider.npm.as_deref()) {
+		if npm.to_ascii_lowercase().contains("anthropic") {
+			return CredentialType::Anthropic;
+		}
+	}
+
+	CredentialType::Openai
+}
+
+fn provider_base(provider: &OpenCodeProvider) -> Option<String> {
+	let options = provider.options.as_ref()?;
+	clean_string(
+		options
+			.endpoint
+			.clone()
+			.or_else(|| options.base_url.clone()),
+	)
+}
+
+fn provider_config_key(provider: &OpenCodeProvider) -> Option<String> {
+	let raw_key = provider
+		.options
+		.as_ref()
+		.and_then(|options| options.api_key.clone())?;
+	resolve_value(raw_key)
+}
+
+fn resolve_value(raw_value: String) -> Option<String> {
+	let trimmed = raw_value.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+
+	if let Some(env_name) = trimmed
+		.strip_prefix("{env:")
+		.and_then(|value| value.strip_suffix('}'))
+	{
+		return std::env::var(env_name)
+			.ok()
+			.and_then(|value| clean_string(Some(value)));
+	}
+
+	if let Some(file_path) = trimmed
+		.strip_prefix("{file:")
+		.and_then(|value| value.strip_suffix('}'))
+	{
+		let path = resolve_file_path(file_path);
+		return fs::read_to_string(path)
+			.ok()
+			.and_then(|value| clean_string(Some(value)));
+	}
+
+	Some(trimmed.to_string())
+}
+
+fn resolve_file_path(file_path: &str) -> PathBuf {
+	if let Some(stripped) = file_path.strip_prefix("~/") {
+		if let Some(home) = home_dir() {
+			return home.join(stripped);
+		}
+	}
+	PathBuf::from(file_path)
+}
+
+fn clean_string(value: Option<String>) -> Option<String> {
+	value.and_then(|value| {
+		let trimmed = value.trim();
+		if trimmed.is_empty() {
+			None
+		} else {
+			Some(trimmed.to_string())
+		}
+	})
+}
+
 pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	id: "opencode",
 	display_name: "OpenCode",
@@ -141,6 +394,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents,
 	save_sub_agents,
+	import_credientials,
 	cli_name: "opencode",
 	validate_args: &["--version"],
 	project_markers: &[".opencode"],

--- a/crates/agents/src/agents/opencode/inference.rs
+++ b/crates/agents/src/agents/opencode/inference.rs
@@ -1,7 +1,7 @@
 use crate::descriptor::home_dir;
 use crate::errors::ConfigError;
 use crate::models::{Credential, CredentialType, ResourceScope};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -80,17 +80,27 @@ fn load_provider_config(
 			Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
 			Err(e) => return Err(e.into()),
 		};
-		let config: OpenCodeConfig =
-			serde_json::from_str(&content).map_err(|e| {
-				ConfigError::InvalidConfig(format!(
-					"Failed to parse OpenCode config {}: {e}",
-					path.display()
-				))
-			})?;
+		let config = parse_provider_config(&content, &path)?;
 		providers.extend(config.provider);
 	}
 
 	Ok(providers)
+}
+
+fn parse_provider_config(
+	content: &str,
+	path: &Path,
+) -> crate::Result<OpenCodeConfig> {
+	if let Ok(config) = serde_json::from_str(content) {
+		return Ok(config);
+	}
+
+	json5::from_str(content).map_err(|e| {
+		ConfigError::InvalidConfig(format!(
+			"Failed to parse OpenCode config {}: {e}",
+			path.display()
+		))
+	})
 }
 
 fn provider_config_paths(
@@ -99,23 +109,82 @@ fn provider_config_paths(
 ) -> crate::Result<Vec<PathBuf>> {
 	match scope {
 		ResourceScope::GlobalOnly => {
-			Ok(super::mcp::global_path().into_iter().collect())
+			Ok(dedup_paths(global_provider_config_paths()))
 		}
 		ResourceScope::ProjectOnly => {
 			let Some(root) = project_root else {
 				return Ok(Vec::new());
 			};
-			let mut paths = Vec::new();
+			let mut paths =
+				vec![root.join("opencode.json"), root.join("opencode.jsonc")];
 			if let Some(path) = super::mcp::project_path(root) {
 				paths.push(path);
 			}
-			paths.push(root.join("opencode.json"));
-			Ok(paths)
+			Ok(dedup_paths(paths))
 		}
 		ResourceScope::Both => Err(ConfigError::InvalidConfig(
 			"Credential path unavailable for Both scope".to_string(),
 		)),
 	}
+}
+
+fn global_provider_config_paths() -> Vec<PathBuf> {
+	let mut paths = Vec::new();
+
+	if let Some(home) = home_dir() {
+		let config_dir = home.join(".config/opencode");
+		paths.push(config_dir.join("opencode.json"));
+		paths.push(config_dir.join("opencode.jsonc"));
+	}
+
+	if let Some(custom_path) = std::env::var_os("OPENCODE_CONFIG") {
+		paths.push(PathBuf::from(custom_path));
+	}
+
+	paths.extend(managed_provider_config_paths());
+	paths
+}
+
+fn managed_provider_config_paths() -> Vec<PathBuf> {
+	let mut paths = Vec::new();
+
+	#[cfg(target_os = "macos")]
+	{
+		let base = PathBuf::from("/Library/Application Support/opencode");
+		paths.push(base.join("opencode.json"));
+		paths.push(base.join("opencode.jsonc"));
+	}
+
+	#[cfg(target_os = "linux")]
+	{
+		let base = PathBuf::from("/etc/opencode");
+		paths.push(base.join("opencode.json"));
+		paths.push(base.join("opencode.jsonc"));
+	}
+
+	#[cfg(target_os = "windows")]
+	{
+		if let Some(program_data) = std::env::var_os("ProgramData") {
+			let base = PathBuf::from(program_data).join("opencode");
+			paths.push(base.join("opencode.json"));
+			paths.push(base.join("opencode.jsonc"));
+		}
+	}
+
+	paths
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+	let mut seen = HashSet::new();
+	let mut deduped = Vec::new();
+
+	for path in paths {
+		if seen.insert(path.clone()) {
+			deduped.push(path);
+		}
+	}
+
+	deduped
 }
 
 fn load_auth_keys() -> crate::Result<HashMap<String, String>> {
@@ -254,4 +323,159 @@ fn clean_string(value: Option<String>) -> Option<String> {
 			Some(trimmed.to_string())
 		}
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::ffi::OsString;
+	use std::sync::Mutex;
+	use tempfile::TempDir;
+
+	static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	struct EnvVarGuard {
+		key: &'static str,
+		previous: Option<OsString>,
+	}
+
+	impl EnvVarGuard {
+		fn set(key: &'static str, value: Option<OsString>) -> Self {
+			let previous = std::env::var_os(key);
+			match value {
+				Some(value) => std::env::set_var(key, value),
+				None => std::env::remove_var(key),
+			}
+			Self { key, previous }
+		}
+	}
+
+	impl Drop for EnvVarGuard {
+		fn drop(&mut self) {
+			match self.previous.take() {
+				Some(value) => std::env::set_var(self.key, value),
+				None => std::env::remove_var(self.key),
+			}
+		}
+	}
+
+	fn write_file(path: &Path, content: &str) {
+		if let Some(parent) = path.parent() {
+			fs::create_dir_all(parent).unwrap();
+		}
+		fs::write(path, content).unwrap();
+	}
+
+	#[test]
+	fn import_credentials_reads_base_from_jsonc_and_key_from_auth() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		let temp = TempDir::new().unwrap();
+		let home = temp.path().join("home");
+		let xdg_data_home = temp.path().join("xdg-data");
+
+		let _home_guard =
+			EnvVarGuard::set("HOME", Some(home.clone().into_os_string()));
+		let _xdg_data_guard = EnvVarGuard::set(
+			"XDG_DATA_HOME",
+			Some(xdg_data_home.clone().into_os_string()),
+		);
+		let _custom_guard = EnvVarGuard::set("OPENCODE_CONFIG", None);
+
+		write_file(
+			&home.join(".config/opencode/opencode.jsonc"),
+			r#"{
+	// base lives in config
+	"provider": {
+		"custom-provider": {
+			"options": {
+				"baseURL": "https://api.example.com/v1",
+			},
+		},
+	},
+}"#,
+		);
+		write_file(
+			&xdg_data_home.join("opencode/auth.json"),
+			r#"{
+	"custom-provider": {
+		"type": "api",
+		"key": "sk-test"
+	}
+}"#,
+		);
+
+		let credentials =
+			import_credentials(None, ResourceScope::GlobalOnly).unwrap();
+
+		assert_eq!(credentials.len(), 1);
+		assert_eq!(credentials[0].name, "custom-provider");
+		assert_eq!(
+			credentials[0].base.as_deref(),
+			Some("https://api.example.com/v1")
+		);
+		assert_eq!(credentials[0].key.as_deref(), Some("sk-test"));
+	}
+
+	#[test]
+	fn import_credentials_prefers_opencode_config_env_file() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		let temp = TempDir::new().unwrap();
+		let home = temp.path().join("home");
+		let xdg_data_home = temp.path().join("xdg-data");
+		let custom_config = temp.path().join("custom/opencode.json");
+
+		let _home_guard =
+			EnvVarGuard::set("HOME", Some(home.clone().into_os_string()));
+		let _xdg_data_guard = EnvVarGuard::set(
+			"XDG_DATA_HOME",
+			Some(xdg_data_home.clone().into_os_string()),
+		);
+		let _custom_guard = EnvVarGuard::set(
+			"OPENCODE_CONFIG",
+			Some(custom_config.clone().into_os_string()),
+		);
+
+		write_file(
+			&home.join(".config/opencode/opencode.json"),
+			r#"{
+	"provider": {
+		"custom-provider": {
+			"options": {
+				"baseURL": "https://global.example.com/v1"
+			}
+		}
+	}
+}"#,
+		);
+		write_file(
+			&custom_config,
+			r#"{
+	"provider": {
+		"custom-provider": {
+			"options": {
+				"baseURL": "https://custom.example.com/v1"
+			}
+		}
+	}
+}"#,
+		);
+		write_file(
+			&xdg_data_home.join("opencode/auth.json"),
+			r#"{
+	"custom-provider": {
+		"type": "api",
+		"key": "sk-test"
+	}
+}"#,
+		);
+
+		let credentials =
+			import_credentials(None, ResourceScope::GlobalOnly).unwrap();
+
+		assert_eq!(credentials.len(), 1);
+		assert_eq!(
+			credentials[0].base.as_deref(),
+			Some("https://custom.example.com/v1")
+		);
+	}
 }

--- a/crates/agents/src/agents/opencode/inference.rs
+++ b/crates/agents/src/agents/opencode/inference.rs
@@ -1,130 +1,34 @@
-use crate::descriptor::*;
+use crate::descriptor::home_dir;
 use crate::errors::ConfigError;
-use crate::models::{Credential, CredentialType};
-use crate::sub_agents::{load_scoped_sub_agents, save_scoped_sub_agents};
+use crate::models::{Credential, CredentialType, ResourceScope};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, serde::Deserialize)]
-struct OpenCodeConfig {
+pub(super) struct OpenCodeConfig {
 	#[serde(default)]
-	provider: HashMap<String, OpenCodeProvider>,
+	pub(super) provider: HashMap<String, OpenCodeProvider>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
-struct OpenCodeProvider {
-	npm: Option<String>,
-	options: Option<OpenCodeProviderOptions>,
+pub(super) struct OpenCodeProvider {
+	pub(super) npm: Option<String>,
+	pub(super) options: Option<OpenCodeProviderOptions>,
 }
 
 #[derive(Debug, Default, serde::Deserialize)]
-struct OpenCodeProviderOptions {
+pub(super) struct OpenCodeProviderOptions {
 	#[serde(rename = "baseURL")]
-	base_url: Option<String>,
-	endpoint: Option<String>,
+	pub(super) base_url: Option<String>,
+	pub(super) endpoint: Option<String>,
 	#[serde(rename = "apiKey")]
-	api_key: Option<String>,
+	pub(super) api_key: Option<String>,
 }
 
-fn mcp_global_path() -> Option<PathBuf> {
-	home_dir().map(|home| home.join(".config/opencode/opencode.json"))
-}
-fn mcp_project_path(root: &Path) -> Option<PathBuf> {
-	Some(root.join(".opencode/settings.json"))
-}
-fn global_data_dir() -> Option<PathBuf> {
-	home_dir().map(|home| home.join(".config/opencode"))
-}
-fn load_mcps(
+pub(super) fn import_credentials(
 	project_root: Option<&Path>,
-	scope: crate::ResourceScope,
-) -> crate::Result<Vec<crate::McpServer>> {
-	load_scoped_mcps(
-		project_root,
-		scope,
-		Some(mcp_global_path),
-		Some(mcp_project_path),
-		mcp_strategy::PARSE_JSON_OPCODE,
-	)
-}
-fn save_mcps(
-	project_root: Option<&Path>,
-	scope: crate::ResourceScope,
-	mcps: &[crate::McpServer],
-) -> crate::Result<()> {
-	save_scoped_mcps(
-		project_root,
-		scope,
-		mcps,
-		Some(mcp_global_path),
-		Some(mcp_project_path),
-		mcp_strategy::SERIALIZE_JSON_OPCODE,
-	)
-}
-fn global_skills_paths() -> Vec<PathBuf> {
-	let Some(home) = home_dir() else {
-		return Vec::new();
-	};
-	vec![
-		home.join(".config/opencode/skills"),
-		home.join(".claude/skills"),
-		home.join(".agents/skills"),
-	]
-}
-fn project_skills_paths(root: &Path) -> Vec<PathBuf> {
-	vec![
-		root.join(".opencode/skills"),
-		root.join(".claude/skills"),
-		root.join(".agents/skills"),
-	]
-}
-
-fn global_skill_write_path() -> Option<PathBuf> {
-	home_dir().map(|home| home.join(".config/opencode/skills"))
-}
-
-fn project_skill_write_path(root: &Path) -> Option<PathBuf> {
-	Some(root.join(".opencode/skills"))
-}
-
-fn sub_agent_global_dir() -> Option<PathBuf> {
-	home_dir().map(|home| home.join(".config/opencode/agents"))
-}
-
-fn sub_agent_project_dir(root: &Path) -> Option<PathBuf> {
-	Some(root.join(".opencode/agents"))
-}
-
-fn load_sub_agents(
-	project_root: Option<&Path>,
-	scope: crate::ResourceScope,
-) -> crate::Result<Vec<crate::SubAgent>> {
-	load_scoped_sub_agents(
-		project_root,
-		scope,
-		Some(sub_agent_global_dir),
-		Some(sub_agent_project_dir),
-	)
-}
-
-fn save_sub_agents(
-	project_root: Option<&Path>,
-	scope: crate::ResourceScope,
-	agents: &[crate::SubAgent],
-) -> crate::Result<()> {
-	save_scoped_sub_agents(
-		project_root,
-		scope,
-		agents,
-		Some(sub_agent_global_dir),
-		Some(sub_agent_project_dir),
-	)
-}
-
-fn import_credientials(
-	project_root: Option<&Path>,
-	scope: crate::ResourceScope,
+	scope: ResourceScope,
 ) -> crate::Result<Vec<Credential>> {
 	let providers = load_provider_config(project_root, scope)?;
 	let auth_entries = load_auth_keys()?;
@@ -166,7 +70,7 @@ fn import_credientials(
 
 fn load_provider_config(
 	project_root: Option<&Path>,
-	scope: crate::ResourceScope,
+	scope: ResourceScope,
 ) -> crate::Result<HashMap<String, OpenCodeProvider>> {
 	let mut providers = HashMap::new();
 
@@ -191,24 +95,24 @@ fn load_provider_config(
 
 fn provider_config_paths(
 	project_root: Option<&Path>,
-	scope: crate::ResourceScope,
+	scope: ResourceScope,
 ) -> crate::Result<Vec<PathBuf>> {
 	match scope {
-		crate::ResourceScope::GlobalOnly => {
-			Ok(mcp_global_path().into_iter().collect())
+		ResourceScope::GlobalOnly => {
+			Ok(super::mcp::global_path().into_iter().collect())
 		}
-		crate::ResourceScope::ProjectOnly => {
+		ResourceScope::ProjectOnly => {
 			let Some(root) = project_root else {
 				return Ok(Vec::new());
 			};
 			let mut paths = Vec::new();
-			if let Some(path) = mcp_project_path(root) {
+			if let Some(path) = super::mcp::project_path(root) {
 				paths.push(path);
 			}
 			paths.push(root.join("opencode.json"));
 			Ok(paths)
 		}
-		crate::ResourceScope::Both => Err(ConfigError::InvalidConfig(
+		ResourceScope::Both => Err(ConfigError::InvalidConfig(
 			"Credential path unavailable for Both scope".to_string(),
 		)),
 	}
@@ -284,7 +188,7 @@ fn infer_provider_type(
 	CredentialType::Openai
 }
 
-fn provider_base(provider: &OpenCodeProvider) -> Option<String> {
+pub(super) fn provider_base(provider: &OpenCodeProvider) -> Option<String> {
 	let options = provider.options.as_ref()?;
 	clean_string(
 		options
@@ -294,7 +198,9 @@ fn provider_base(provider: &OpenCodeProvider) -> Option<String> {
 	)
 }
 
-fn provider_config_key(provider: &OpenCodeProvider) -> Option<String> {
+pub(super) fn provider_config_key(
+	provider: &OpenCodeProvider,
+) -> Option<String> {
 	let raw_key = provider
 		.options
 		.as_ref()
@@ -349,54 +255,3 @@ fn clean_string(value: Option<String>) -> Option<String> {
 		}
 	})
 }
-
-pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
-	id: "opencode",
-	display_name: "OpenCode",
-	mcp_parse_config: Some(mcp_strategy::PARSE_JSON_OPCODE),
-	mcp_serialize_config: Some(mcp_strategy::SERIALIZE_JSON_OPCODE),
-	load_mcps,
-	save_mcps,
-	mcp_global_path: Some(mcp_global_path),
-	mcp_project_path: Some(mcp_project_path),
-	global_data_dir,
-	capabilities: Capabilities {
-		skills: SkillCapabilities {
-			scopes: ScopeSupport {
-				global: true,
-				project: true,
-			},
-			universal: false,
-		},
-		mcp: McpCapabilities {
-			scopes: ScopeSupport {
-				global: true,
-				project: true,
-			},
-			stdio: true,
-			remote: true,
-			enable_disable: true,
-		},
-		sub_agents: SubAgentCapabilities {
-			scopes: ScopeSupport {
-				global: true,
-				project: true,
-			},
-		},
-	},
-	global_skill_paths: Some(GlobalSkillPaths {
-		read: global_skills_paths,
-		write: global_skill_write_path,
-	}),
-	project_skill_paths: Some(ProjectSkillPaths {
-		read: project_skills_paths,
-		write: project_skill_write_path,
-	}),
-	load_sub_agents,
-	save_sub_agents,
-	import_credientials,
-	cli_name: "opencode",
-	validate_args: &["--version"],
-	project_markers: &[".opencode"],
-	skills_cli_name: Some("opencode"),
-};

--- a/crates/agents/src/agents/opencode/mcp.rs
+++ b/crates/agents/src/agents/opencode/mcp.rs
@@ -1,0 +1,38 @@
+use crate::descriptor::*;
+use std::path::{Path, PathBuf};
+
+pub(super) fn global_path() -> Option<PathBuf> {
+	home_dir().map(|home| home.join(".config/opencode/opencode.json"))
+}
+
+pub(super) fn project_path(root: &Path) -> Option<PathBuf> {
+	Some(root.join(".opencode/settings.json"))
+}
+
+pub(super) fn load(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+) -> crate::Result<Vec<crate::McpServer>> {
+	load_scoped_mcps(
+		project_root,
+		scope,
+		Some(global_path),
+		Some(project_path),
+		mcp_strategy::PARSE_JSON_OPCODE,
+	)
+}
+
+pub(super) fn save(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+	mcps: &[crate::McpServer],
+) -> crate::Result<()> {
+	save_scoped_mcps(
+		project_root,
+		scope,
+		mcps,
+		Some(global_path),
+		Some(project_path),
+		mcp_strategy::SERIALIZE_JSON_OPCODE,
+	)
+}

--- a/crates/agents/src/agents/opencode/mod.rs
+++ b/crates/agents/src/agents/opencode/mod.rs
@@ -1,11 +1,12 @@
-use crate::define_mcp_paths;
+mod inference;
+mod mcp;
+mod sub_agent;
+
 use crate::descriptor::*;
 use std::path::{Path, PathBuf};
 
-define_mcp_paths! {
-	symmetric: ".cursor/mcp.json",
-	strategy: mcp_strategy::parse_json_map_mcp_servers,
-			  mcp_strategy::serialize_json_map_mcp_servers,
+fn global_data_dir() -> Option<PathBuf> {
+	home_dir().map(|home| home.join(".config/opencode"))
 }
 
 fn global_skills_paths() -> Vec<PathBuf> {
@@ -13,37 +14,37 @@ fn global_skills_paths() -> Vec<PathBuf> {
 		return Vec::new();
 	};
 	vec![
-		home.join(".cursor/skills"),
+		home.join(".config/opencode/skills"),
 		home.join(".claude/skills"),
-		home.join(".codex/skills"),
+		home.join(".agents/skills"),
 	]
 }
+
 fn project_skills_paths(root: &Path) -> Vec<PathBuf> {
 	vec![
-		root.join(".cursor/skills"),
-		root.join(".agents/skills"),
+		root.join(".opencode/skills"),
 		root.join(".claude/skills"),
-		root.join(".codex/skills"),
+		root.join(".agents/skills"),
 	]
 }
 
 fn global_skill_write_path() -> Option<PathBuf> {
-	home_dir().map(|home| home.join(".cursor/skills"))
+	home_dir().map(|home| home.join(".config/opencode/skills"))
 }
 
 fn project_skill_write_path(root: &Path) -> Option<PathBuf> {
-	Some(root.join(".cursor/skills"))
+	Some(root.join(".opencode/skills"))
 }
 
 pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
-	id: "cursor",
-	display_name: "Cursor",
-	mcp_parse_config: Some(mcp_strategy::parse_json_map_mcp_servers),
-	mcp_serialize_config: Some(mcp_strategy::serialize_json_map_mcp_servers),
-	load_mcps,
-	save_mcps,
-	mcp_global_path: Some(mcp_global_path),
-	mcp_project_path: Some(mcp_project_path),
+	id: "opencode",
+	display_name: "OpenCode",
+	mcp_parse_config: Some(mcp_strategy::PARSE_JSON_OPCODE),
+	mcp_serialize_config: Some(mcp_strategy::SERIALIZE_JSON_OPCODE),
+	load_mcps: mcp::load,
+	save_mcps: mcp::save,
+	mcp_global_path: Some(mcp::global_path),
+	mcp_project_path: Some(mcp::project_path),
 	global_data_dir,
 	capabilities: Capabilities {
 		skills: SkillCapabilities {
@@ -60,12 +61,12 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 			},
 			stdio: true,
 			remote: true,
-			enable_disable: false,
+			enable_disable: true,
 		},
 		sub_agents: SubAgentCapabilities {
 			scopes: ScopeSupport {
-				global: false,
-				project: false,
+				global: true,
+				project: true,
 			},
 		},
 	},
@@ -77,11 +78,11 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 		read: project_skills_paths,
 		write: project_skill_write_path,
 	}),
-	load_sub_agents: load_sub_agents_noop,
-	save_sub_agents: save_sub_agents_noop,
-	import_credentials: import_credentials_noop,
-	cli_name: "cursor",
+	load_sub_agents: sub_agent::load,
+	save_sub_agents: sub_agent::save,
+	import_credentials: inference::import_credentials,
+	cli_name: "opencode",
 	validate_args: &["--version"],
-	project_markers: &[".cursor"],
-	skills_cli_name: Some("cursor"),
+	project_markers: &[".opencode"],
+	skills_cli_name: Some("opencode"),
 };

--- a/crates/agents/src/agents/opencode/sub_agent.rs
+++ b/crates/agents/src/agents/opencode/sub_agent.rs
@@ -1,0 +1,37 @@
+use crate::descriptor::home_dir;
+use crate::sub_agents::{load_scoped_sub_agents, save_scoped_sub_agents};
+use std::path::{Path, PathBuf};
+
+fn global_dir() -> Option<PathBuf> {
+	home_dir().map(|home| home.join(".config/opencode/agents"))
+}
+
+fn project_dir(root: &Path) -> Option<PathBuf> {
+	Some(root.join(".opencode/agents"))
+}
+
+pub(super) fn load(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+) -> crate::Result<Vec<crate::SubAgent>> {
+	load_scoped_sub_agents(
+		project_root,
+		scope,
+		Some(global_dir),
+		Some(project_dir),
+	)
+}
+
+pub(super) fn save(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+	agents: &[crate::SubAgent],
+) -> crate::Result<()> {
+	save_scoped_sub_agents(
+		project_root,
+		scope,
+		agents,
+		Some(global_dir),
+		Some(project_dir),
+	)
+}

--- a/crates/agents/src/agents/pi.rs
+++ b/crates/agents/src/agents/pi.rs
@@ -84,6 +84,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "pi",
 	validate_args: &["--version"],
 	project_markers: &[".pi"],

--- a/crates/agents/src/agents/pi.rs
+++ b/crates/agents/src/agents/pi.rs
@@ -84,7 +84,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "pi",
 	validate_args: &["--version"],
 	project_markers: &[".pi"],

--- a/crates/agents/src/agents/roocode.rs
+++ b/crates/agents/src/agents/roocode.rs
@@ -56,6 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "roocode",
 	validate_args: &["--version"],
 	project_markers: &[".roo"],

--- a/crates/agents/src/agents/roocode.rs
+++ b/crates/agents/src/agents/roocode.rs
@@ -56,7 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "roocode",
 	validate_args: &["--version"],
 	project_markers: &[".roo"],

--- a/crates/agents/src/agents/trae.rs
+++ b/crates/agents/src/agents/trae.rs
@@ -56,7 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "trae",
 	validate_args: &["--version"],
 	project_markers: &[".trae"],

--- a/crates/agents/src/agents/trae.rs
+++ b/crates/agents/src/agents/trae.rs
@@ -56,6 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "trae",
 	validate_args: &["--version"],
 	project_markers: &[".trae"],

--- a/crates/agents/src/agents/warp.rs
+++ b/crates/agents/src/agents/warp.rs
@@ -56,7 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "warp",
 	validate_args: &["--version"],
 	project_markers: &[".warp"],

--- a/crates/agents/src/agents/warp.rs
+++ b/crates/agents/src/agents/warp.rs
@@ -56,6 +56,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "warp",
 	validate_args: &["--version"],
 	project_markers: &[".warp"],

--- a/crates/agents/src/agents/windsurf.rs
+++ b/crates/agents/src/agents/windsurf.rs
@@ -59,6 +59,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "windsurf",
 	validate_args: &["--version"],
 	project_markers: &[".windsurf"],

--- a/crates/agents/src/agents/windsurf.rs
+++ b/crates/agents/src/agents/windsurf.rs
@@ -59,7 +59,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	}),
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "windsurf",
 	validate_args: &["--version"],
 	project_markers: &[".windsurf"],

--- a/crates/agents/src/agents/zed.rs
+++ b/crates/agents/src/agents/zed.rs
@@ -49,6 +49,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "zed",
 	validate_args: &["--version"],
 	project_markers: &[".zed"],

--- a/crates/agents/src/agents/zed.rs
+++ b/crates/agents/src/agents/zed.rs
@@ -49,7 +49,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "zed",
 	validate_args: &["--version"],
 	project_markers: &[".zed"],

--- a/crates/agents/src/descriptor.rs
+++ b/crates/agents/src/descriptor.rs
@@ -1,6 +1,6 @@
 use crate::errors::{ConfigError, Result};
 use crate::models::{
-	AgentConfig, McpServer, McpTransport, ResourceScope, SubAgent,
+	AgentConfig, Credential, McpServer, McpTransport, ResourceScope, SubAgent,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -28,6 +28,10 @@ pub type LoadSubAgentsFn =
 /// The implementation fully owns all I/O; no path is exposed.
 pub type SaveSubAgentsFn =
 	fn(Option<&Path>, ResourceScope, &[SubAgent]) -> Result<()>;
+
+/// Import function type for agent credentials.
+pub type ImportCredientialsFn =
+	fn(Option<&Path>, ResourceScope) -> Result<Vec<Credential>>;
 
 pub type OptionalPathFn = fn() -> Option<PathBuf>;
 pub type OptionalProjectPathFn = fn(&Path) -> Option<PathBuf>;
@@ -103,6 +107,8 @@ pub struct AgentDescriptor {
 	/// Persist sub-agents for the requested scope.
 	/// Implementation is fully internal — no path information is exposed.
 	pub save_sub_agents: SaveSubAgentsFn,
+	/// Import credentials for the requested scope.
+	pub import_credientials: ImportCredientialsFn,
 	pub cli_name: &'static str,
 	pub validate_args: &'static [&'static str],
 	/// Directory/file markers that indicate this agent's project root
@@ -258,6 +264,14 @@ impl AgentDescriptor {
 			ResourceScope::Both => None,
 		}
 	}
+
+	pub fn import_credientials(
+		&self,
+		project_root: Option<&Path>,
+		scope: ResourceScope,
+	) -> Result<Vec<Credential>> {
+		(self.import_credientials)(project_root, scope)
+	}
 }
 
 /// Get the universal skills directory path following XDG config spec
@@ -385,6 +399,14 @@ pub fn save_sub_agents_noop(
 	_: &[SubAgent],
 ) -> Result<()> {
 	Ok(())
+}
+
+/// No-op credentials importer for agents that do not support credentials.
+pub fn import_credientials_noop(
+	_: Option<&Path>,
+	_: ResourceScope,
+) -> Result<Vec<Credential>> {
+	Ok(Vec::new())
 }
 
 /// MCP config strategy functions for common config formats

--- a/crates/agents/src/descriptor.rs
+++ b/crates/agents/src/descriptor.rs
@@ -30,7 +30,7 @@ pub type SaveSubAgentsFn =
 	fn(Option<&Path>, ResourceScope, &[SubAgent]) -> Result<()>;
 
 /// Import function type for agent credentials.
-pub type ImportCredientialsFn =
+pub type ImportCredentialsFn =
 	fn(Option<&Path>, ResourceScope) -> Result<Vec<Credential>>;
 
 pub type OptionalPathFn = fn() -> Option<PathBuf>;
@@ -108,7 +108,7 @@ pub struct AgentDescriptor {
 	/// Implementation is fully internal — no path information is exposed.
 	pub save_sub_agents: SaveSubAgentsFn,
 	/// Import credentials for the requested scope.
-	pub import_credientials: ImportCredientialsFn,
+	pub import_credentials: ImportCredentialsFn,
 	pub cli_name: &'static str,
 	pub validate_args: &'static [&'static str],
 	/// Directory/file markers that indicate this agent's project root
@@ -265,12 +265,12 @@ impl AgentDescriptor {
 		}
 	}
 
-	pub fn import_credientials(
+	pub fn import_credentials(
 		&self,
 		project_root: Option<&Path>,
 		scope: ResourceScope,
 	) -> Result<Vec<Credential>> {
-		(self.import_credientials)(project_root, scope)
+		(self.import_credentials)(project_root, scope)
 	}
 }
 
@@ -402,7 +402,7 @@ pub fn save_sub_agents_noop(
 }
 
 /// No-op credentials importer for agents that do not support credentials.
-pub fn import_credientials_noop(
+pub fn import_credentials_noop(
 	_: Option<&Path>,
 	_: ResourceScope,
 ) -> Result<Vec<Credential>> {

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -7,13 +7,13 @@ pub mod models;
 pub mod sub_agents;
 
 pub use descriptor::{
-	AgentDescriptor, Capabilities, GlobalSkillPaths, LoadMcpsFn,
-	LoadSubAgentsFn, McpCapabilities, McpParseFn, McpSerializeFn,
+	AgentDescriptor, Capabilities, GlobalSkillPaths, ImportCredientialsFn,
+	LoadMcpsFn, LoadSubAgentsFn, McpCapabilities, McpParseFn, McpSerializeFn,
 	ProjectSkillPaths, SaveMcpsFn, SaveSubAgentsFn, ScopeSupport,
 	SkillCapabilities, SubAgentCapabilities,
 };
 pub use errors::{ConfigError, Result};
 pub use models::{
-	AgentConfig, AgentType, ConfigSource, McpServer, McpTransport,
-	ResourceScope, Skill, SubAgent,
+	AgentConfig, AgentType, ConfigSource, Credential, CredentialType,
+	McpServer, McpTransport, ResourceScope, Skill, SubAgent,
 };

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -7,7 +7,7 @@ pub mod models;
 pub mod sub_agents;
 
 pub use descriptor::{
-	AgentDescriptor, Capabilities, GlobalSkillPaths, ImportCredientialsFn,
+	AgentDescriptor, Capabilities, GlobalSkillPaths, ImportCredentialsFn,
 	LoadMcpsFn, LoadSubAgentsFn, McpCapabilities, McpParseFn, McpSerializeFn,
 	ProjectSkillPaths, SaveMcpsFn, SaveSubAgentsFn, ScopeSupport,
 	SkillCapabilities, SubAgentCapabilities,

--- a/crates/agents/src/models.rs
+++ b/crates/agents/src/models.rs
@@ -205,13 +205,24 @@ pub enum CredentialType {
 }
 
 /// Provider credential imported from an agent config
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Credential {
 	pub name: String,
 	#[serde(rename = "type")]
 	pub r#type: CredentialType,
 	pub base: Option<String>,
 	pub key: Option<String>,
+}
+
+impl std::fmt::Debug for Credential {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Credential")
+			.field("name", &self.name)
+			.field("type", &self.r#type)
+			.field("base", &self.base)
+			.field("key", &self.key.as_ref().map(|_| "<redacted>"))
+			.finish()
+	}
 }
 
 impl Credential {

--- a/crates/agents/src/models.rs
+++ b/crates/agents/src/models.rs
@@ -196,6 +196,35 @@ impl McpTransport {
 	}
 }
 
+/// Credential request format
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CredentialType {
+	Openai,
+	Anthropic,
+}
+
+/// Provider credential imported from an agent config
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Credential {
+	pub name: String,
+	#[serde(rename = "type")]
+	pub r#type: CredentialType,
+	pub base: Option<String>,
+	pub key: Option<String>,
+}
+
+impl Credential {
+	pub fn new(name: impl Into<String>, r#type: CredentialType) -> Self {
+		Self {
+			name: name.into(),
+			r#type,
+			base: None,
+			key: None,
+		}
+	}
+}
+
 pub(crate) fn default_true() -> bool {
 	true
 }

--- a/crates/core/tests/mcp_tests.rs
+++ b/crates/core/tests/mcp_tests.rs
@@ -18,7 +18,7 @@
 use aghub_core::{
 	adapters::AgentAdapter,
 	descriptor::{
-		import_credientials_noop, load_scoped_mcps, load_sub_agents_noop,
+		import_credentials_noop, load_scoped_mcps, load_sub_agents_noop,
 		mcp_strategy, save_scoped_mcps, save_sub_agents_noop, Capabilities,
 		McpCapabilities, ScopeSupport, SkillCapabilities, SubAgentCapabilities,
 	},
@@ -101,7 +101,7 @@ static ADAPTER_TEST_DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
-	import_credientials: import_credientials_noop,
+	import_credentials: import_credentials_noop,
 	cli_name: "adapter-test",
 	validate_args: &[],
 	project_markers: &[],

--- a/crates/core/tests/mcp_tests.rs
+++ b/crates/core/tests/mcp_tests.rs
@@ -18,9 +18,9 @@
 use aghub_core::{
 	adapters::AgentAdapter,
 	descriptor::{
-		load_scoped_mcps, load_sub_agents_noop, mcp_strategy, save_scoped_mcps,
-		save_sub_agents_noop, Capabilities, McpCapabilities, ScopeSupport,
-		SkillCapabilities, SubAgentCapabilities,
+		import_credientials_noop, load_scoped_mcps, load_sub_agents_noop,
+		mcp_strategy, save_scoped_mcps, save_sub_agents_noop, Capabilities,
+		McpCapabilities, ScopeSupport, SkillCapabilities, SubAgentCapabilities,
 	},
 	models::{AgentType, McpServer, McpTransport},
 	testing::{TestConfig, TestConfigBuilder},
@@ -101,6 +101,7 @@ static ADAPTER_TEST_DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	project_skill_paths: None,
 	load_sub_agents: load_sub_agents_noop,
 	save_sub_agents: save_sub_agents_noop,
+	import_credientials: import_credientials_noop,
 	cli_name: "adapter-test",
 	validate_args: &[],
 	project_markers: &[],


### PR DESCRIPTION
## Summary
- add `Credential` / `CredentialType` to `agents` models (`name`, `type`, `base`, `key`)
- extend `AgentDescriptor` with `import_credientials` import API and no-op default
- implement real credential importers for `codex` and `opencode`
  - `codex`: only custom providers with overridden `base_url` (non-official providers only)
  - `opencode`: merge provider config with auth storage credentials
- wire all other agents to no-op importer for now

## Validation
- `cargo test -p aghub-agents`
- `cargo test -p aghub-core --test mcp_tests`
- `cargo clippy -p aghub-agents -- -D warnings`

Part 1 of **inference provider support**.
Related to #17.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent credential management: Credentials now importable from configuration files
  * Codex: TOML-based credential configuration with global and project-level scope support
  * OpenCode: JSON/JSON5 credential configuration with multi-provider endpoint management
  * New credential types: OpenAI and Anthropic providers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->