### PR TITLE
fix(agents): handle Codex official MCP format with extra fields

### DIFF
--- a/crates/agents/src/format/toml_format.rs
+++ b/crates/agents/src/format/toml_format.rs
@@ -2,41 +2,60 @@ use crate::{
 	errors::{ConfigError, Result},
 	models::{AgentConfig, McpServer, McpTransport},
 };
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct TomlConfig {
-	#[serde(default)]
-	mcp_servers: HashMap<String, TomlMcpServer>,
-	#[serde(flatten)]
-	extra: toml::map::Map<String, toml::Value>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct TomlMcpServer {
-	command: String,
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	args: Vec<String>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	env: Option<HashMap<String, String>>,
+fn parse_toml(content: &str) -> Result<toml::Value> {
+	toml::from_str(content).map_err(|e| {
+		ConfigError::InvalidConfig(format!("Failed to parse TOML: {e}"))
+	})
 }
 
 pub fn parse(content: &str) -> Result<AgentConfig> {
-	let toml_config: TomlConfig = toml::from_str(content).map_err(|e| {
-		ConfigError::InvalidConfig(format!("Failed to parse TOML config: {e}"))
-	})?;
-
+	let doc = parse_toml(content)?;
 	let mut config = AgentConfig::new();
 
-	for (name, server) in toml_config.mcp_servers {
+	let Some(servers) = doc.get("mcp_servers").and_then(|v| v.as_table())
+	else {
+		return Ok(config);
+	};
+
+	for (name, entry) in servers {
+		let table = match entry.as_table() {
+			Some(t) => t,
+			None => continue,
+		};
+		let Some(command) = table.get("command").and_then(|v| v.as_str())
+		else {
+			continue;
+		};
+		let args = table
+			.get("args")
+			.and_then(|v| v.as_array())
+			.map(|arr| {
+				arr.iter()
+					.filter_map(|v| v.as_str().map(String::from))
+					.collect()
+			})
+			.unwrap_or_default();
+		let env = table
+			.get("env")
+			.and_then(|v| v.as_table())
+			.map(|t| {
+				t.iter()
+					.filter_map(|(k, v)| {
+						v.as_str().map(|s| (k.clone(), s.to_string()))
+					})
+					.collect::<HashMap<_, _>>()
+			})
+			.filter(|m| !m.is_empty());
+
 		config.mcps.push(McpServer {
-			name,
+			name: name.clone(),
 			enabled: true,
 			transport: McpTransport::Stdio {
-				command: server.command,
-				args: server.args,
-				env: server.env,
+				command: command.to_string(),
+				args,
+				env,
 				timeout: None,
 			},
 			timeout: None,
@@ -51,43 +70,95 @@ pub fn serialize(
 	config: &AgentConfig,
 	original_content: Option<&str>,
 ) -> Result<String> {
-	let mut toml_config = if let Some(content) = original_content {
-		if content.trim().is_empty() {
-			TomlConfig::default()
-		} else {
-			toml::from_str::<TomlConfig>(content).map_err(|e| {
-				ConfigError::InvalidConfig(format!(
-					"Failed to parse existing config: {e}"
-				))
-			})?
-		}
-	} else {
-		TomlConfig::default()
+	let mut doc = match original_content {
+		Some(c) if !c.trim().is_empty() => parse_toml(c)?,
+		_ => toml::Value::Table(toml::map::Map::new()),
 	};
 
-	toml_config.mcp_servers.clear();
+	let root = doc.as_table_mut().ok_or_else(|| {
+		ConfigError::InvalidConfig("root is not a table".into())
+	})?;
 
+	// Get or create the mcp_servers table.
+	if !root.contains_key("mcp_servers") {
+		root.insert(
+			"mcp_servers".to_string(),
+			toml::Value::Table(toml::map::Map::new()),
+		);
+	}
+	let servers = root
+		.get_mut("mcp_servers")
+		.and_then(|v| v.as_table_mut())
+		.ok_or_else(|| {
+			ConfigError::InvalidConfig("mcp_servers is not a table".into())
+		})?;
+
+	// Collect the names aghub manages this round.
+	let managed: std::collections::HashSet<String> =
+		config.mcps.iter().map(|m| m.name.clone()).collect();
+
+	// Remove servers that aghub no longer tracks.
+	servers.retain(|name, _| managed.contains(name));
+
+	// Upsert each server: merge aghub fields into existing entry.
 	for mcp in &config.mcps {
 		if !mcp.enabled {
+			servers.remove(&mcp.name);
 			continue;
 		}
-		if let McpTransport::Stdio {
+		let McpTransport::Stdio {
 			command, args, env, ..
 		} = &mcp.transport
-		{
-			toml_config.mcp_servers.insert(
-				mcp.name.clone(),
-				TomlMcpServer {
-					command: command.clone(),
-					args: args.clone(),
-					env: env.clone(),
-				},
+		else {
+			continue;
+		};
+
+		let entry = servers
+			.entry(&mcp.name)
+			.or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+		let table = match entry.as_table_mut() {
+			Some(t) => t,
+			None => continue,
+		};
+
+		table.insert(
+			"command".to_string(),
+			toml::Value::String(command.clone()),
+		);
+
+		if args.is_empty() {
+			table.remove("args");
+		} else {
+			table.insert(
+				"args".to_string(),
+				toml::Value::Array(
+					args.iter()
+						.map(|a| toml::Value::String(a.clone()))
+						.collect(),
+				),
 			);
 		}
-		// SSE/HTTP not supported in TOML format
+
+		match env {
+			Some(env_map) if !env_map.is_empty() => {
+				let mut env_table = toml::map::Map::new();
+				for (k, v) in env_map {
+					env_table.insert(k.clone(), toml::Value::String(v.clone()));
+				}
+				table.insert("env".to_string(), toml::Value::Table(env_table));
+			}
+			_ => {
+				table.remove("env");
+			}
+		}
 	}
 
-	toml::to_string_pretty(&toml_config)
+	// Remove empty mcp_servers table.
+	if servers.is_empty() {
+		root.remove("mcp_servers");
+	}
+
+	toml::to_string_pretty(&doc)
 		.map_err(|e| ConfigError::InvalidConfig(e.to_string()))
 }
 
@@ -97,7 +168,7 @@ mod tests {
 	use crate::models::{McpServer, McpTransport};
 
 	#[test]
-	fn test_parse_toml_config() {
+	fn parse_basic_servers() {
 		let content = r#"
 model = "o3"
 
@@ -122,7 +193,38 @@ env = { DISPLAY = ":0" }
 	}
 
 	#[test]
-	fn test_roundtrip_preserves_extra_fields() {
+	fn parse_codex_format_with_type_and_tools() {
+		let content = r#"
+[mcp_servers.pencil]
+type = "stdio"
+command = "/path/to/pencil"
+args = ["--app", "desktop"]
+
+[mcp_servers.playwright]
+command = "npx"
+args = ["@playwright/mcp@latest"]
+
+[mcp_servers.playwright.tools.browser_navigate]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_click]
+approval_mode = "approve"
+"#;
+		let config = parse(content).unwrap();
+		assert_eq!(config.mcps.len(), 2);
+
+		let pencil = config.mcps.iter().find(|m| m.name == "pencil").unwrap();
+		match &pencil.transport {
+			McpTransport::Stdio { command, args, .. } => {
+				assert_eq!(command, "/path/to/pencil");
+				assert_eq!(args, &["--app", "desktop"]);
+			}
+			_ => panic!("Expected Stdio"),
+		}
+	}
+
+	#[test]
+	fn roundtrip_preserves_non_mcp_fields() {
 		let original = r#"
 model_provider = "custom"
 model = "gpt-5.4"
@@ -140,7 +242,60 @@ command = "old-cmd"
 		let output = serialize(&updated, Some(original)).unwrap();
 		assert!(output.contains("model_provider"));
 		assert!(output.contains("gpt-5.4"));
-		assert!(!output.contains("[mcp_servers.old]"));
-		assert!(output.contains("[mcp_servers.new-mcp]"));
+		assert!(!output.contains("old-cmd"));
+		assert!(output.contains("new-mcp"));
+	}
+
+	#[test]
+	fn roundtrip_preserves_tools_and_type() {
+		let original = r#"
+[mcp_servers.playwright]
+command = "npx"
+args = ["@playwright/mcp@latest"]
+
+[mcp_servers.playwright.tools.browser_navigate]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_click]
+approval_mode = "approve"
+"#;
+		let config = parse(original).unwrap();
+		let output = serialize(&config, Some(original)).unwrap();
+		assert!(output.contains("browser_navigate"));
+		assert!(output.contains("browser_click"));
+		assert!(output.contains("approval_mode"));
+	}
+
+	#[test]
+	fn add_server_preserves_existing_tools() {
+		let original = r#"
+[mcp_servers.playwright]
+command = "npx"
+args = ["@playwright/mcp@latest"]
+
+[mcp_servers.playwright.tools.browser_navigate]
+approval_mode = "approve"
+"#;
+		let mut config = parse(original).unwrap();
+		config.mcps.push(McpServer::new(
+			"new-mcp",
+			McpTransport::stdio("new-cmd", vec!["arg1".into()]),
+		));
+		let output = serialize(&config, Some(original)).unwrap();
+		// New server added.
+		assert!(output.contains("new-mcp"));
+		assert!(output.contains("new-cmd"));
+		// Existing tools preserved.
+		assert!(output.contains("browser_navigate"));
+		assert!(output.contains("approval_mode"));
+	}
+
+	#[test]
+	fn no_mcp_servers_section_parses_empty() {
+		let content = r#"
+model = "gpt-5.4"
+"#;
+		let config = parse(content).unwrap();
+		assert!(config.mcps.is_empty());
 	}
 }


### PR DESCRIPTION
Fixes #110

## Problem

When Codex's official MCP tool installs servers, it writes additional fields (`type`, nested `tools` with `approval_mode`) to `config.toml`:

```toml
[mcp_servers.pencil]
type = "stdio"
command = "/path/to/pencil"

[mcp_servers.playwright.tools.browser_navigate]
approval_mode = "approve"
```

aghub's TOML parser used a rigid `TomlMcpServer` struct with only `command`, `args`, `env`. Any unknown field caused deserialization to fail, making aghub unable to read or write MCP config afterward.

## Root Cause

The parser serialized/deserialized through a typed struct, which is lossy — fields the struct doesn't know about are either rejected (on read) or silently dropped (on write).

## Fix

Rewrite `toml_format.rs` to operate directly on `toml::Value` DOM instead of typed structs:

- **Parse**: walk the `mcp_servers` table, extract `command`/`args`/`env` from each entry. Unknown fields are simply not read — they stay in the DOM.
- **Serialize**: merge aghub's fields into existing entries via upsert. Fields aghub doesn't manage (`type`, `tools`, `approval_mode`, etc.) are preserved untouched.
- **Delete**: only remove servers aghub explicitly no longer tracks.

No data is lost during the read-modify-write cycle.

## Test plan

- [x] `parse_basic_servers` — standard format
- [x] `parse_codex_format_with_type_and_tools` — Codex official format with `type` and nested `tools`
- [x] `roundtrip_preserves_non_mcp_fields` — non-MCP config fields preserved
- [x] `roundtrip_preserves_tools_and_type` — `tools` and `approval_mode` survive roundtrip
- [x] `add_server_preserves_existing_tools` — adding new server doesn't drop existing tools
- [x] `no_mcp_servers_section_parses_empty` — config without MCP section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TOML configuration parsing and serialization to better preserve non-MCP fields and subsections
  * Fixed handling of configurations without MCP server sections
  * Enhanced configuration updates to correctly add or modify servers while retaining existing elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->