### PR TITLE
Disable model fetching for Anthropic providers

### DIFF
--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -288,6 +288,8 @@ export default {
 		"No new models to add ({{total}} already configured)",
 	fetchProviderModelsFailed: "Failed to fetch models: {{reason}}",
 	fetchProviderModelsUnknownError: "endpoint not supported",
+	fetchProviderModelsUnsupportedAnthropic:
+		"Anthropic providers do not support fetching model lists.",
 	noProviderModels: "No models configured.",
 	noProviderModelsMatch: "No models match your search.",
 	providerModelGroupUncategorized: "Uncategorized",

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -276,6 +276,8 @@ export default {
 		"没有新模型需要添加（已配置 {{total}} 个）",
 	fetchProviderModelsFailed: "获取模型失败：{{reason}}",
 	fetchProviderModelsUnknownError: "端点不支持",
+	fetchProviderModelsUnsupportedAnthropic:
+		"Anthropic Provider 不支持获取模型列表。",
 	noProviderModels: "暂无模型。",
 	noProviderModelsMatch: "没有匹配的模型。",
 	providerModelGroupUncategorized: "未分类",

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -275,6 +275,8 @@ export default {
 	fetchProviderModelsSuccessNoNew: "沒有新模型需新增（已設定 {{total}} 個）",
 	fetchProviderModelsFailed: "擷取模型失敗：{{reason}}",
 	fetchProviderModelsUnknownError: "端點不支援",
+	fetchProviderModelsUnsupportedAnthropic:
+		"Anthropic Provider 不支援擷取模型列表。",
 	noProviderModels: "尚無模型。",
 	noProviderModelsMatch: "沒有相符的模型。",
 	providerModelGroupUncategorized: "未分類",

--- a/crates/desktop/src/pages/inference-providers.tsx
+++ b/crates/desktop/src/pages/inference-providers.tsx
@@ -107,6 +107,10 @@ const FORMAT_OPTIONS: FormatOption[] = [
 const TRAILING_SLASHES_REGEX = /\/+$/;
 const PROVIDER_EXISTS_REGEX = /provider already exists:\s*(.+)/i;
 
+function canFetchProviderModels(format: InferenceProviderFormatDto) {
+	return format !== "anthropic";
+}
+
 async function fetchProviderModels({
 	format,
 	apiBaseUrl,
@@ -116,19 +120,17 @@ async function fetchProviderModels({
 	apiBaseUrl: string;
 	apiKey: string;
 }): Promise<string[]> {
+	if (!canFetchProviderModels(format)) {
+		throw new Error("Model fetching is not available for Anthropic");
+	}
+
 	const trimmedBase = apiBaseUrl.trim().replace(TRAILING_SLASHES_REGEX, "");
 	if (!trimmedBase) throw new Error("Missing API base URL");
 	if (!apiKey.trim()) throw new Error("Missing API key");
 
-	const headers: Record<string, string> =
-		format === "anthropic"
-			? {
-					"x-api-key": apiKey,
-					"anthropic-version": "2023-06-01",
-				}
-			: {
-					Authorization: `Bearer ${apiKey}`,
-				};
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${apiKey}`,
+	};
 
 	const response = await fetch(`${trimmedBase}/models`, {
 		method: "GET",
@@ -312,6 +314,7 @@ function ProviderModelsEditor({
 	errorMessage,
 	onFetchModels,
 	canFetchModels = false,
+	fetchModelsDisabledReason,
 }: {
 	value: ProviderModelFormValue[];
 	onChange: (value: ProviderModelFormValue[]) => void;
@@ -319,6 +322,7 @@ function ProviderModelsEditor({
 	errorMessage?: string;
 	onFetchModels?: () => Promise<string[]>;
 	canFetchModels?: boolean;
+	fetchModelsDisabledReason?: string;
 }) {
 	const { t } = useTranslation();
 	const emptyModel = useMemo(() => createProviderModelFormValue(), []);
@@ -509,6 +513,30 @@ function ProviderModelsEditor({
 		</div>
 	);
 
+	const fetchModelsButton = onFetchModels ? (
+		<Button
+			type="button"
+			variant="tertiary"
+			size="sm"
+			isPending={isFetching}
+			isDisabled={!canFetchModels}
+			onPress={handleFetch}
+		>
+			{({ isPending }) => (
+				<>
+					{isPending ? (
+						<Spinner color="current" size="sm" />
+					) : (
+						<CloudArrowDownIcon className="size-4" />
+					)}
+					{isPending
+						? t("fetchProviderModelsPending")
+						: t("fetchProviderModels")}
+				</>
+			)}
+		</Button>
+	) : null;
+
 	return (
 		<>
 			<div className="grid gap-2">
@@ -520,32 +548,19 @@ function ProviderModelsEditor({
 						</p>
 					</div>
 					<div className="flex shrink-0 items-center gap-2">
-						{onFetchModels && (
-							<Button
-								type="button"
-								variant="tertiary"
-								size="sm"
-								isPending={isFetching}
-								isDisabled={!canFetchModels}
-								onPress={handleFetch}
-							>
-								{({ isPending }) => (
-									<>
-										{isPending ? (
-											<Spinner
-												color="current"
-												size="sm"
-											/>
-										) : (
-											<CloudArrowDownIcon className="size-4" />
-										)}
-										{isPending
-											? t("fetchProviderModelsPending")
-											: t("fetchProviderModels")}
-									</>
-								)}
-							</Button>
-						)}
+						{fetchModelsButton &&
+							(fetchModelsDisabledReason ? (
+								<Tooltip delay={0}>
+									<Tooltip.Trigger>
+										{fetchModelsButton}
+									</Tooltip.Trigger>
+									<Tooltip.Content>
+										{fetchModelsDisabledReason}
+									</Tooltip.Content>
+								</Tooltip>
+							) : (
+								fetchModelsButton
+							))}
 						<Button
 							type="button"
 							variant="secondary"
@@ -801,14 +816,24 @@ function ProviderForm({
 	};
 
 	const [showApiKey, setShowApiKey] = useState(false);
+	const watchedFormat = useWatch({ control, name: "format" });
 	const watchedApiBaseUrl = useWatch({ control, name: "apiBaseUrl" });
 	const watchedApiKey = useWatch({ control, name: "apiKey" });
+	const fetchModelsDisabledReason = !canFetchProviderModels(watchedFormat)
+		? t("fetchProviderModelsUnsupportedAnthropic")
+		: undefined;
 	const canFetchModels = Boolean(
-		watchedApiBaseUrl?.trim() && watchedApiKey?.trim(),
+		canFetchProviderModels(watchedFormat) &&
+		watchedApiBaseUrl?.trim() &&
+		watchedApiKey?.trim(),
 	);
 
 	const handleFetchModels = async () => {
 		const values = getValues();
+		if (!canFetchProviderModels(values.format)) {
+			throw new Error(t("fetchProviderModelsUnsupportedAnthropic"));
+		}
+
 		return fetchProviderModels({
 			format: values.format,
 			apiBaseUrl: values.apiBaseUrl,
@@ -1273,6 +1298,9 @@ function ProviderForm({
 											}
 											onFetchModels={handleFetchModels}
 											canFetchModels={canFetchModels}
+											fetchModelsDisabledReason={
+												fetchModelsDisabledReason
+											}
 										/>
 									)}
 								/>


### PR DESCRIPTION
## Summary
- Disable the Fetch models action when the inference provider format is Anthropic.
- Add a guard so Anthropic cannot trigger the model-list request even if the UI is bypassed.
- Add localized disabled-state copy for English, Simplified Chinese, and Traditional Chinese.

## Testing
- cd crates/desktop && bun run format:check
- cd crates/desktop && bun run typecheck
- cd crates/desktop && bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational tooltips explaining when model fetching is unavailable for Anthropic providers.
  * Extended multi-language support with translations for unsupported model fetching messages across English, Simplified Chinese, and Traditional Chinese.

* **Chores**
  * Updated inference provider handling to reflect Anthropic provider limitations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/aghub/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->