### PR TITLE
Stop Codex provider env writes

### DIFF
--- a/crates/inference/src/codex/files.rs
+++ b/crates/inference/src/codex/files.rs
@@ -44,16 +44,6 @@ pub(super) fn read_auth(path: &Path) -> Result<Value> {
 		.map_err(|error| invalid_credential_store(path, error.to_string()))
 }
 
-pub(super) fn write_auth(path: &Path, auth: &Value) -> Result<()> {
-	if let Some(parent) = path.parent() {
-		fs::create_dir_all(parent)?;
-	}
-	let json = serde_json::to_string_pretty(auth)
-		.map_err(|error| invalid_credential_store(path, error.to_string()))?;
-	fs::write(path, json)?;
-	Ok(())
-}
-
 pub(super) fn default_global_config_path() -> Result<PathBuf> {
 	let codex_home = std::env::var_os("CODEX_HOME")
 		.map(PathBuf::from)

--- a/crates/inference/src/codex/mapping.rs
+++ b/crates/inference/src/codex/mapping.rs
@@ -161,15 +161,6 @@ pub(super) fn clean_provider_id(provider_id: &str) -> Result<String> {
 	Ok(provider_id)
 }
 
-pub(super) fn clean_provider_name(name: &str) -> Result<String> {
-	let name = name.trim().to_string();
-	if name.is_empty() {
-		Err(InferenceProviderError::EmptyName)
-	} else {
-		Ok(name)
-	}
-}
-
 pub(super) fn ensure_api_key(api_key: &str) -> Result<()> {
 	if api_key.trim().is_empty() {
 		Err(InferenceProviderError::EmptyApiKey)
@@ -208,29 +199,23 @@ fn apply_credential(
 	api_key: Option<&str>,
 ) {
 	match credential {
-		AgentProviderCredential::EnvVar { name } => {
-			let _ = api_key;
-			table["env_key"] = value(name.clone());
-			table.remove("experimental_bearer_token");
-			table.remove("requires_openai_auth");
-			table.remove("auth");
-			remove_authorization_header(table);
-		}
-		AgentProviderCredential::AgentStore { .. } => {
-			table.remove("env_key");
-			table.remove("experimental_bearer_token");
-			remove_authorization_header(table);
-			if table.get("auth").is_none() {
-				table["requires_openai_auth"] = value(true);
-			}
-		}
-		AgentProviderCredential::Inline => {
+		AgentProviderCredential::EnvVar { .. }
+		| AgentProviderCredential::Inline => {
 			table.remove("env_key");
 			table.remove("requires_openai_auth");
 			table.remove("auth");
 			if let Some(api_key) = api_key {
 				table["experimental_bearer_token"] = value(api_key.to_string());
 				remove_authorization_header(table);
+			}
+		}
+		AgentProviderCredential::AgentStore { .. } => {
+			table.remove("env_key");
+			table.remove("experimental_bearer_token");
+			table.remove("requires_openai_auth");
+			remove_authorization_header(table);
+			if table.get("auth").is_none() {
+				table["requires_openai_auth"] = value(true);
 			}
 		}
 		AgentProviderCredential::None => {

--- a/crates/inference/src/codex/mod.rs
+++ b/crates/inference/src/codex/mod.rs
@@ -22,7 +22,10 @@ use crate::agent::{
 use crate::credentials::CredentialStore;
 use crate::error::Result;
 use crate::model::InferenceProvider;
-use crate::store::{InferenceProviderRepository, InferenceProviderStore};
+use crate::store::{
+	AgentProviderBindingRow, InferenceProviderRepository,
+	InferenceProviderStore,
+};
 
 pub(super) const AGENT_ID: &str = "codex";
 pub const DEFAULT_PROFILE_ID: &str = "default";
@@ -342,71 +345,27 @@ impl CodexProviderAdapter {
 				store.set_api_key(&provider.id, api_key)?;
 			}
 
-			return store.binding_from_row(row);
+			return binding_from_row(store, row);
 		}
 
-		// Not a binding provider - check config.toml
-		let mut config = files::read_config(&self.config_path)?;
-		let provider = provider_table(&config, &provider_id)?
-			.cloned()
-			.ok_or_else(|| {
-				crate::error::InferenceProviderError::NotFound(
-					provider_id.clone(),
-				)
-			})?;
-
-		// Config.toml providers are External and cannot be updated via aghub
-		let binding = mapping::binding_from_table(&provider_id, &provider)?;
-		if binding.source == AgentProviderSource::External {
-			return Err(
-				crate::error::InferenceProviderError::InvalidAgentProviderConfig {
-					agent_id: AGENT_ID.to_string(),
-					path: self.config_path.display().to_string(),
-					message: format!(
-						"codex provider '{provider_id}' is defined in \
-						 config.toml and cannot be updated via aghub"
-					),
-				},
-			);
+		let config = files::read_config(&self.config_path)?;
+		let exists = provider_table(&config, &provider_id)?.is_some();
+		if !exists {
+			return Err(crate::error::InferenceProviderError::NotFound(
+				provider_id,
+			));
 		}
 
-		let name = name.map(mapping::clean_provider_name).transpose()?;
-		if let Some(api_key) = api_key {
-			mapping::ensure_api_key(api_key)?;
-			if mapping::uses_auth_command(&provider) {
-				return Err(
-					crate::error::InferenceProviderError::InvalidAgentProviderConfig {
-						agent_id: AGENT_ID.to_string(),
-						path: self.config_path.display().to_string(),
-						message: format!(
-							"codex provider '{provider_id}' uses \
-							 command-backed auth and cannot be updated \
-							 with an inline API key"
-						),
-					},
-				);
-			}
-		}
-
-		let mut binding = mapping::binding_from_table(&provider_id, &provider)?;
-		mapping::ensure_responses_format(binding.format)?;
-		if let Some(name) = name {
-			binding.name = name;
-		}
-		upsert_provider(&mut config, &binding, api_key)?;
-		files::write_config(&self.config_path, &config)?;
-		if let Some(api_key) = api_key {
-			if mapping::uses_shared_openai_api_key(&provider) {
-				self.write_shared_openai_api_key(api_key)?;
-			}
-		}
-
-		Ok(self
-			.load_providers()?
-			.providers
-			.into_iter()
-			.find(|provider| provider.id == provider_id)
-			.unwrap_or(binding))
+		Err(
+			crate::error::InferenceProviderError::InvalidAgentProviderConfig {
+				agent_id: AGENT_ID.to_string(),
+				path: self.config_path.display().to_string(),
+				message: format!(
+					"codex provider '{provider_id}' is defined in \
+					 config.toml and cannot be updated via aghub"
+				),
+			},
+		)
 	}
 
 	/// Read an API key visible to Codex for a provider.
@@ -459,7 +418,7 @@ impl CodexProviderAdapter {
 		// Check binding table first
 		let binding_rows = store.list_agent_bindings(AGENT_ID)?;
 		if let Some(row) = binding_rows.iter().find(|r| r.id == provider_id) {
-			let binding = store.binding_from_row(row)?;
+			let binding = binding_from_row(store, row)?;
 			store.delete_agent_binding(AGENT_ID, &row.id)?;
 
 			// Also remove from config.toml if present
@@ -480,44 +439,24 @@ impl CodexProviderAdapter {
 			return Ok(binding);
 		}
 
-		// Not a binding provider - check config.toml
-		let mut config = files::read_config(&self.config_path)?;
-		let removed = provider_table(&config, &provider_id)?
-			.map(|table| mapping::binding_from_table(&provider_id, table))
-			.transpose()?
-			.ok_or_else(|| {
-				crate::error::InferenceProviderError::NotFound(
-					provider_id.clone(),
-				)
-			})?;
-
-		// Config.toml providers are External and cannot be deleted via aghub
-		if removed.source == AgentProviderSource::External {
-			return Err(
-				crate::error::InferenceProviderError::InvalidAgentProviderConfig {
-					agent_id: AGENT_ID.to_string(),
-					path: self.config_path.display().to_string(),
-					message: format!(
-						"Provider '{provider_id}' is defined in config.toml, \
-						 cannot delete via aghub"
-					),
-				},
-			);
+		let config = files::read_config(&self.config_path)?;
+		let exists = provider_table(&config, &provider_id)?.is_some();
+		if !exists {
+			return Err(crate::error::InferenceProviderError::NotFound(
+				provider_id,
+			));
 		}
 
-		let providers = providers_table_mut(&mut config)?;
-		providers.remove(&provider_id);
-		if config
-			.get("model_provider")
-			.and_then(Item::as_str)
-			.is_some_and(|value| value == provider_id)
-		{
-			config.as_table_mut().remove("model_provider");
-			config.as_table_mut().remove("model");
-		}
-		clear_profile_provider_references(&mut config, &provider_id);
-		files::write_config(&self.config_path, &config)?;
-		Ok(removed)
+		Err(
+			crate::error::InferenceProviderError::InvalidAgentProviderConfig {
+				agent_id: AGENT_ID.to_string(),
+				path: self.config_path.display().to_string(),
+				message: format!(
+					"Provider '{provider_id}' is defined in config.toml, \
+					 cannot delete via aghub"
+				),
+			},
+		)
 	}
 
 	/// Load all providers including those from the binding table.
@@ -553,7 +492,7 @@ impl CodexProviderAdapter {
 		// Load binding table providers (marked as Custom)
 		let binding_rows = store.list_agent_bindings(AGENT_ID)?;
 		for row in binding_rows {
-			let binding = store.binding_from_row(&row)?;
+			let binding = binding_from_row(store, &row)?;
 			if let Some(existing) =
 				providers.iter_mut().find(|p| p.id == binding.id)
 			{
@@ -577,23 +516,6 @@ impl CodexProviderAdapter {
 			return store.get_api_key(&row.inference_provider_id);
 		}
 		Ok(None)
-	}
-
-	fn write_shared_openai_api_key(&self, api_key: &str) -> Result<()> {
-		let mut auth = files::read_auth(&self.auth_path)?;
-		let Some(auth_object) = auth.as_object_mut() else {
-			return Err(
-				crate::error::InferenceProviderError::InvalidAgentCredentialStore {
-					agent_id: AGENT_ID.to_string(),
-					path: self.auth_path.display().to_string(),
-					message: "auth.json must contain a JSON object"
-						.to_string(),
-				},
-			);
-		};
-		auth_object
-			.insert("OPENAI_API_KEY".to_string(), serde_json::json!(api_key));
-		files::write_auth(&self.auth_path, &auth)
 	}
 }
 
@@ -792,6 +714,17 @@ fn normalize_inventory_base_url(api_base_url: &str) -> String {
 	} else {
 		trimmed.to_string()
 	}
+}
+
+fn binding_from_row<C: CredentialStore>(
+	store: &InferenceProviderStore<C>,
+	row: &AgentProviderBindingRow,
+) -> Result<AgentProviderBinding> {
+	let mut binding = store.binding_from_row(row)?;
+	if matches!(binding.credential, AgentProviderCredential::EnvVar { .. }) {
+		binding.credential = AgentProviderCredential::Inline;
+	}
+	Ok(binding)
 }
 
 fn upsert_provider(

--- a/crates/inference/src/codex/tests.rs
+++ b/crates/inference/src/codex/tests.rs
@@ -466,7 +466,7 @@ model_provider = "openai"
 }
 
 #[test]
-fn set_active_provider_preserves_inventory_key_reference() {
+fn set_active_provider_writes_inventory_key_inline() {
 	let temp = tempfile::tempdir().unwrap();
 	let adapter = adapter(&temp);
 	fs::write(adapter.config_path(), r#"model_provider = "openai""#).unwrap();
@@ -485,10 +485,10 @@ fn set_active_provider_preserves_inventory_key_reference() {
 		.unwrap();
 	let provider = config["model_providers"]["openrouter"].as_table().unwrap();
 	assert_eq!(
-		provider["env_key"].as_str(),
-		Some("AGHUB_INFERENCE_API_KEY")
+		provider["experimental_bearer_token"].as_str(),
+		Some("sk-test")
 	);
-	assert!(provider.get("experimental_bearer_token").is_none());
+	assert!(provider.get("env_key").is_none());
 }
 
 #[test]
@@ -623,11 +623,12 @@ fn add_inventory_provider_uses_stable_public_id() {
 		.collect::<Vec<_>>();
 	assert_eq!(openrouter.len(), 1);
 	assert_eq!(openrouter[0].source, AgentProviderSource::Custom);
+	assert_eq!(openrouter[0].credential, AgentProviderCredential::Inline);
 	assert_eq!(openrouter[0].models[0].id, "openai/gpt-5.4");
 }
 
 #[test]
-fn update_provider_edits_name_and_token_preserving_comments() {
+fn update_provider_rejects_config_toml_provider() {
 	let temp = tempfile::tempdir().unwrap();
 	let adapter = adapter(&temp);
 	fs::write(
@@ -646,30 +647,33 @@ experimental_bearer_token = "sk-old"
 	.unwrap();
 
 	let store = store(&temp);
-	let binding = adapter
+	let error = adapter
 		.update_provider(
 			&store,
 			"openrouter",
 			Some("OpenRouter Team"),
 			Some("sk-new"),
 		)
-		.unwrap();
+		.unwrap_err();
 
-	assert_eq!(binding.name, "OpenRouter Team");
+	assert!(matches!(
+		error,
+		InferenceProviderError::InvalidAgentProviderConfig { .. }
+	));
 	let content = fs::read_to_string(adapter.config_path()).unwrap();
 	assert!(content.contains("# user note"));
 	assert!(content.contains("# provider note"));
 	let config = content.parse::<DocumentMut>().unwrap();
 	let provider = config["model_providers"]["openrouter"].as_table().unwrap();
-	assert_eq!(provider["name"].as_str(), Some("OpenRouter Team"));
+	assert_eq!(provider["name"].as_str(), Some("OpenRouter"));
 	assert_eq!(
 		provider["experimental_bearer_token"].as_str(),
-		Some("sk-new")
+		Some("sk-old")
 	);
 }
 
 #[test]
-fn update_provider_preserves_env_key_credentials() {
+fn update_provider_rejects_env_key_config_provider() {
 	let temp = tempfile::tempdir().unwrap();
 	let adapter = adapter(&temp);
 	fs::write(
@@ -685,22 +689,18 @@ env_key = "OPENROUTER_API_KEY"
 	.unwrap();
 
 	let store = store(&temp);
-	let binding = adapter
+	let error = adapter
 		.update_provider(&store, "openrouter", Some("OpenRouter Team"), None)
-		.unwrap();
+		.unwrap_err();
 
-	assert_eq!(binding.name, "OpenRouter Team");
-	assert_eq!(
-		binding.credential,
-		AgentProviderCredential::EnvVar {
-			name: "OPENROUTER_API_KEY".to_string()
-		}
-	);
-
+	assert!(matches!(
+		error,
+		InferenceProviderError::InvalidAgentProviderConfig { .. }
+	));
 	let content = fs::read_to_string(adapter.config_path()).unwrap();
 	let config = content.parse::<DocumentMut>().unwrap();
 	let provider = config["model_providers"]["openrouter"].as_table().unwrap();
-	assert_eq!(provider["name"].as_str(), Some("OpenRouter Team"));
+	assert_eq!(provider["name"].as_str(), Some("OpenRouter"));
 	assert_eq!(provider["env_key"].as_str(), Some("OPENROUTER_API_KEY"));
 	assert!(provider.get("experimental_bearer_token").is_none());
 }
@@ -742,7 +742,7 @@ requires_openai_auth = true
 }
 
 #[test]
-fn update_provider_updates_shared_auth_json_for_openai_auth_provider() {
+fn update_provider_rejects_shared_auth_config_provider() {
 	let temp = tempfile::tempdir().unwrap();
 	let adapter = adapter(&temp);
 	fs::write(
@@ -759,21 +759,18 @@ requires_openai_auth = true
 	fs::write(auth_path(&temp), r#"{ "OPENAI_API_KEY": "sk-old" }"#).unwrap();
 
 	let store = store(&temp);
-	let binding = adapter
+	let error = adapter
 		.update_provider(&store, "newapi", Some("New API"), Some("sk-new"))
-		.unwrap();
+		.unwrap_err();
 
-	assert_eq!(binding.name, "New API");
-	assert_eq!(
-		binding.credential,
-		AgentProviderCredential::AgentStore {
-			id: Some("newapi".to_string())
-		}
-	);
+	assert!(matches!(
+		error,
+		InferenceProviderError::InvalidAgentProviderConfig { .. }
+	));
 	let auth: serde_json::Value =
 		serde_json::from_str(&fs::read_to_string(auth_path(&temp)).unwrap())
 			.unwrap();
-	assert_eq!(auth["OPENAI_API_KEY"].as_str(), Some("sk-new"));
+	assert_eq!(auth["OPENAI_API_KEY"].as_str(), Some("sk-old"));
 }
 
 #[test]
@@ -861,6 +858,40 @@ fn api_key_for_openai_login_provider_is_not_config_backed() {
 }
 
 #[test]
+fn remove_provider_rejects_config_toml_provider() {
+	let temp = tempfile::tempdir().unwrap();
+	let adapter = adapter(&temp);
+	fs::write(
+		adapter.config_path(),
+		r#"
+model = "openai/gpt-5.4"
+model_provider = "openrouter"
+
+[model_providers.openrouter]
+name = "OpenRouter"
+base_url = "https://openrouter.ai/api/v1"
+"#,
+	)
+	.unwrap();
+
+	let store = store(&temp);
+	let error = adapter.remove_provider(&store, "openrouter").unwrap_err();
+
+	assert!(matches!(
+		error,
+		InferenceProviderError::InvalidAgentProviderConfig { .. }
+	));
+	let content = fs::read_to_string(adapter.config_path()).unwrap();
+	let config = content.parse::<DocumentMut>().unwrap();
+	assert_eq!(config["model_provider"].as_str(), Some("openrouter"));
+	assert!(config
+		.get("model_providers")
+		.and_then(Item::as_table)
+		.and_then(|providers| providers.get("openrouter"))
+		.is_some());
+}
+
+#[test]
 fn remove_provider_clears_default_provider() {
 	let temp = tempfile::tempdir().unwrap();
 	let adapter = adapter(&temp);
@@ -878,6 +909,15 @@ base_url = "https://openrouter.ai/api/v1"
 	.unwrap();
 
 	let store = store(&temp);
+	let inventory = create_inventory_provider(&store);
+	store
+		.upsert_agent_binding(
+			AGENT_ID,
+			"openrouter",
+			&inventory.id,
+			Some("openai/gpt-5.4"),
+		)
+		.unwrap();
 	let removed = adapter.remove_provider(&store, "openrouter").unwrap();
 
 	assert_eq!(removed.id, "openrouter");
@@ -918,6 +958,15 @@ wire_api = "responses"
 	.unwrap();
 
 	let store = store(&temp);
+	let inventory = create_inventory_provider(&store);
+	store
+		.upsert_agent_binding(
+			AGENT_ID,
+			"openrouter",
+			&inventory.id,
+			Some("openai/gpt-5.4"),
+		)
+		.unwrap();
 	adapter.remove_provider(&store, "openrouter").unwrap();
 
 	let content = fs::read_to_string(adapter.config_path()).unwrap();


### PR DESCRIPTION
## Summary
- stop Codex managed provider writes from generating env_key references
- reject update/delete for Codex providers defined only in config.toml
- remove active writes to Codex auth.json OPENAI_API_KEY

## Verification
- cargo fmt -p aghub-inference --check
- cargo test -p aghub-inference codex -- --nocapture
- cargo clippy -p aghub-inference -- -D warnings
- cargo test -p aghub-inference