### PR TITLE
Allow OpenCode inline provider API keys

### DIFF
--- a/crates/inference/src/agent.rs
+++ b/crates/inference/src/agent.rs
@@ -668,13 +668,14 @@ mod tests {
 	fn opencode_caps_support_registry_and_qualified_models() {
 		let caps = AgentProviderCapabilities::registry(
 			AgentProviderDefaultSupport::QUALIFIED_MODELS,
-			AgentCredentialSupport::ENV_VAR_OR_AGENT_STORE,
+			AgentCredentialSupport::ENV_VAR_INLINE_OR_AGENT_STORE,
 			BuiltInProviderSupport::OVERRIDABLE,
 		);
 
 		assert!(caps.supports(AgentProviderCapability::CustomProviders));
 		assert!(caps.supports(AgentProviderCapability::MultipleProviders));
 		assert!(caps.supports(AgentProviderCapability::ProviderQualifiedModel));
+		assert!(caps.supports(AgentProviderCapability::InlineApiKeyCredentials));
 		assert!(!caps.supports(AgentProviderCapability::DefaultProvider));
 	}
 
@@ -775,7 +776,7 @@ mod tests {
 	fn state_validation_accepts_opencode_qualified_selection() {
 		let caps = AgentProviderCapabilities::registry(
 			AgentProviderDefaultSupport::QUALIFIED_MODELS,
-			AgentCredentialSupport::ENV_VAR_OR_AGENT_STORE,
+			AgentCredentialSupport::ENV_VAR_INLINE_OR_AGENT_STORE,
 			BuiltInProviderSupport::OVERRIDABLE,
 		);
 		let state = AgentProviderState {

--- a/crates/inference/src/opencode/files.rs
+++ b/crates/inference/src/opencode/files.rs
@@ -105,7 +105,7 @@ fn existing_content(path: &Path) -> Result<Option<String>> {
 	}
 }
 
-fn home_dir_error() -> InferenceProviderError {
+pub(super) fn home_dir_error() -> InferenceProviderError {
 	InferenceProviderError::Io(std::io::Error::new(
 		std::io::ErrorKind::NotFound,
 		"home directory not found",

--- a/crates/inference/src/opencode/mod.rs
+++ b/crates/inference/src/opencode/mod.rs
@@ -1,8 +1,8 @@
 //! OpenCode provider configuration adapter.
 //!
-//! OpenCode splits provider configuration and credentials. Provider metadata
-//! lives in `opencode.json`, while credentials written by `/connect` live in
-//! `~/.local/share/opencode/auth.json`.
+//! OpenCode stores provider configuration in `opencode.json`. Credentials can
+//! live in `~/.local/share/opencode/auth.json` when written by `/connect`, or
+//! in provider `options.apiKey` config values.
 
 mod files;
 mod mapping;
@@ -12,6 +12,7 @@ mod schema;
 mod tests;
 
 use std::collections::HashSet;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
@@ -179,6 +180,9 @@ impl OpenCodeProviderAdapter {
 		if let Some(env_name) = parse_env_var_ref(api_key) {
 			return Ok(std::env::var(env_name).ok());
 		}
+		if let Some(file_path) = parse_file_var_ref(api_key) {
+			return read_api_key_file(&self.config_path, file_path);
+		}
 
 		Ok(Some(api_key.to_string()))
 	}
@@ -244,6 +248,51 @@ fn parse_env_var_ref(value: &str) -> Option<&str> {
 	}
 }
 
+fn parse_file_var_ref(value: &str) -> Option<&str> {
+	let path = value.strip_prefix("{file:")?.strip_suffix('}')?.trim();
+	if path.is_empty() {
+		None
+	} else {
+		Some(path)
+	}
+}
+
+fn read_api_key_file(
+	config_path: &Path,
+	file_path: &str,
+) -> Result<Option<String>> {
+	let path = resolve_file_var_path(config_path, file_path)?;
+	let content = fs::read_to_string(path)?;
+	let api_key = content.trim().to_string();
+	if api_key.is_empty() {
+		Ok(None)
+	} else {
+		Ok(Some(api_key))
+	}
+}
+
+fn resolve_file_var_path(
+	config_path: &Path,
+	file_path: &str,
+) -> Result<PathBuf> {
+	let path = if file_path == "~" {
+		dirs::home_dir().ok_or_else(files::home_dir_error)?
+	} else if let Some(rest) = file_path.strip_prefix("~/") {
+		dirs::home_dir()
+			.ok_or_else(files::home_dir_error)?
+			.join(rest)
+	} else {
+		PathBuf::from(file_path)
+	};
+
+	if path.is_absolute() {
+		Ok(path)
+	} else {
+		let base = config_path.parent().unwrap_or_else(|| Path::new("."));
+		Ok(base.join(path))
+	}
+}
+
 impl AgentProviderAdapter for OpenCodeProviderAdapter {
 	fn agent_id(&self) -> &'static str {
 		AGENT_ID
@@ -252,7 +301,7 @@ impl AgentProviderAdapter for OpenCodeProviderAdapter {
 	fn capabilities(&self) -> AgentProviderCapabilities {
 		AgentProviderCapabilities::registry(
 			AgentProviderDefaultSupport::QUALIFIED_MODELS,
-			AgentCredentialSupport::ENV_VAR_OR_AGENT_STORE,
+			AgentCredentialSupport::ENV_VAR_INLINE_OR_AGENT_STORE,
 			BuiltInProviderSupport::OVERRIDABLE,
 		)
 	}

--- a/crates/inference/src/opencode/tests.rs
+++ b/crates/inference/src/opencode/tests.rs
@@ -319,6 +319,68 @@ fn api_key_reads_inline_config_key() {
 }
 
 #[test]
+fn api_key_reads_file_config_key() {
+	let temp = tempfile::tempdir().unwrap();
+	let adapter = adapter(&temp);
+	let secret_dir = temp.path().join("secrets");
+	fs::create_dir_all(&secret_dir).unwrap();
+	fs::write(secret_dir.join("openrouter-key"), "file-key\n").unwrap();
+	fs::write(
+		adapter.config_path(),
+		r#"{
+			"provider": {
+				"local": {
+					"options": { "apiKey": "{file:secrets/openrouter-key}" }
+				}
+			}
+		}"#,
+	)
+	.unwrap();
+
+	assert_eq!(
+		adapter.api_key("local").unwrap().as_deref(),
+		Some("file-key")
+	);
+}
+
+#[test]
+fn save_preserves_inline_config_key() {
+	let temp = tempfile::tempdir().unwrap();
+	let adapter = adapter(&temp);
+	fs::write(
+		adapter.config_path(),
+		r#"{
+			"provider": {
+				"local": {
+					"name": "Local",
+					"options": {
+						"baseURL": "https://api.example.com/v1",
+						"apiKey": "inline-key"
+					}
+				}
+			}
+		}"#,
+	)
+	.unwrap();
+
+	let state = adapter.load_providers().unwrap();
+	assert_eq!(
+		state.providers[0].credential,
+		AgentProviderCredential::Inline
+	);
+	adapter.save_providers(&state).unwrap();
+
+	let config: Value = serde_json::from_str(
+		&fs::read_to_string(adapter.config_path()).unwrap(),
+	)
+	.unwrap();
+	assert_eq!(
+		config["provider"]["local"]["options"]["apiKey"],
+		"inline-key"
+	);
+}
+
+#[test]
 fn save_preserves_auth_only_entries_without_configuring_them() {
 	let temp = tempfile::tempdir().unwrap();
 	let adapter = adapter(&temp);


### PR DESCRIPTION
## Summary
- allow OpenCode provider bindings to keep inline API key credentials
- resolve OpenCode {file:...} API key references alongside {env:...}
- add regression tests for inline and file-backed OpenCode provider keys

## Test plan
- cargo test -p aghub-inference
- cargo clippy -p aghub-inference -- -D warnings