### PR TITLE
fix: report which items failed in bulk delete flows

### DIFF
--- a/crates/desktop/src/components/bulk-delete-dialog.tsx
+++ b/crates/desktop/src/components/bulk-delete-dialog.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import type { ConfigSource } from "../generated/dto";
 import { useApi } from "../hooks/use-api";
+import { BulkOperationError, bulkFailureItemsLabel } from "../lib/bulk-errors";
 import { invalidateMcpQueries } from "../requests/mcps";
 import { invalidateSkillQueries } from "../requests/skills";
 
@@ -102,8 +103,8 @@ export function BulkDeleteDialog({
 					`${resourceType} bulk delete failures:`,
 					failures,
 				);
-				throw new Error(
-					`${failures.length} of ${promises.length} deletions failed`,
+				throw new BulkOperationError(
+					failures.map(({ name, agent }) => ({ name, agent })),
 				);
 			}
 			return { deleted: promises.length };
@@ -120,6 +121,15 @@ export function BulkDeleteDialog({
 		},
 		onError: (error) => {
 			console.error("Bulk delete mutation error:", error);
+			if (error instanceof BulkOperationError) {
+				toast.danger(
+					t(
+						"bulkDeleteFailedItems",
+						bulkFailureItemsLabel(error.failures),
+					),
+				);
+				return;
+			}
 			toast.danger(
 				error instanceof Error ? error.message : t("bulkDeleteFailed"),
 			);

--- a/crates/desktop/src/lib/bulk-errors.ts
+++ b/crates/desktop/src/lib/bulk-errors.ts
@@ -1,0 +1,32 @@
+export interface BulkFailedItem {
+	name: string;
+	agent?: string | null;
+}
+
+export class BulkOperationError extends Error {
+	constructor(public readonly failures: BulkFailedItem[]) {
+		super(`${failures.length} operations failed`);
+		this.name = "BulkOperationError";
+	}
+}
+
+const PREVIEW_COUNT = 3;
+
+export function bulkFailureItemsLabel(failures: BulkFailedItem[]): {
+	count: number;
+	items: string;
+} {
+	const previews = failures
+		.slice(0, PREVIEW_COUNT)
+		.map((item) =>
+			item.agent ? `${item.name} (${item.agent})` : item.name,
+		);
+	const remaining = failures.length - previews.length;
+	return {
+		count: failures.length,
+		items:
+			remaining > 0
+				? `${previews.join(", ")}, +${remaining}`
+				: previews.join(", "),
+	};
+}

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -451,6 +451,7 @@ export default {
 	bulkDeleteMixedConfirm:
 		"Are you sure you want to delete the {{count}} selected resources from this project?",
 	bulkDeleteFailed: "Bulk delete failed",
+	bulkDeleteFailedItems: "{{count}} item(s) failed to delete: {{items}}",
 	starSkill: "Favorite",
 	unstarSkill: "Unfavorite",
 	starServer: "Favorite",

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -436,6 +436,7 @@ export default {
 	bulkDeleteMixedConfirm:
 		"确定要从当前项目中删除这 {{count}} 个被选中的资源吗？",
 	bulkDeleteFailed: "批量删除失败",
+	bulkDeleteFailedItems: "{{count}} 项删除失败: {{items}}",
 	starSkill: "收藏技能",
 	unstarSkill: "取消收藏",
 	starServer: "收藏服务",

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -435,6 +435,7 @@ export default {
 	bulkDeleteMixedConfirm:
 		"確定要從目前專案中刪除這 {{count}} 個被選中的資源嗎？",
 	bulkDeleteFailed: "批次刪除失敗",
+	bulkDeleteFailedItems: "{{count}} 項刪除失敗: {{items}}",
 	starSkill: "收藏技能",
 	unstarSkill: "取消收藏",
 	starServer: "收藏伺服器",

--- a/crates/desktop/src/pages/project/detail.tsx
+++ b/crates/desktop/src/pages/project/detail.tsx
@@ -1,4 +1,5 @@
 import { FolderIcon } from "@heroicons/react/24/solid";
+import { toast } from "@heroui/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
@@ -19,6 +20,7 @@ import { UnifiedResourceList } from "../../components/unified-resource-list";
 import type { McpResponse, SkillResponse } from "../../generated/dto";
 import { useApi } from "../../hooks/use-api";
 import { useProjects } from "../../hooks/use-projects";
+import { bulkFailureItemsLabel } from "../../lib/bulk-errors";
 import { getMcpMergeKey, getSubAgentMergeKey } from "../../lib/utils";
 import { mcpListQueryOptions } from "../../requests/mcps";
 import { skillListQueryOptions } from "../../requests/skills";
@@ -251,18 +253,31 @@ export default function ProjectDetailPage() {
 		mergeKey: string;
 		items: (typeof projectSubAgents)[number][];
 	}) => {
-		await Promise.all(
-			group.items.map((item) => {
-				if (!item.agent) return Promise.resolve(null);
-				return api.subAgents.delete(
+		const itemsWithAgent = group.items.filter(
+			(item): item is typeof item & { agent: string } => !!item.agent,
+		);
+		const results = await Promise.allSettled(
+			itemsWithAgent.map((item) =>
+				api.subAgents.delete(
 					item.name,
 					item.agent,
 					"project",
 					project?.path,
-				);
-			}),
+				),
+			),
 		);
+		const failures = results
+			.map((result, index) => ({ result, item: itemsWithAgent[index] }))
+			.filter(({ result }) => result.status === "rejected")
+			.map(({ item }) => ({ name: item.name, agent: item.agent }));
 		await invalidateSubAgentQueries(queryClient);
+		if (failures.length > 0) {
+			console.error("sub-agent project delete failures:", failures);
+			toast.danger(
+				t("bulkDeleteFailedItems", bulkFailureItemsLabel(failures)),
+			);
+			return;
+		}
 		setSelectedResource(null);
 		setResourceType("");
 	};

--- a/crates/desktop/src/pages/settings/sub-agents.tsx
+++ b/crates/desktop/src/pages/settings/sub-agents.tsx
@@ -33,6 +33,10 @@ import { useAgentAvailability } from "../../hooks/use-agent-availability";
 import { useApi } from "../../hooks/use-api";
 import { AgentIcon } from "../../lib/agent-icons";
 import {
+	BulkOperationError,
+	bulkFailureItemsLabel,
+} from "../../lib/bulk-errors";
+import {
 	filterItemsByAgentIds,
 	getSubAgentMergeKey,
 	sortAgents,
@@ -220,16 +224,28 @@ export default function SubAgentsPage() {
 
 	const deleteMutation = useMutation({
 		mutationFn: async (group: SubAgentGroup) => {
-			await Promise.all(
-				group.items.map((item) => {
-					if (!item.agent) return Promise.resolve(null);
-					return api.subAgents.delete(
+			const itemsWithAgent = group.items.filter(
+				(item): item is typeof item & { agent: string } => !!item.agent,
+			);
+			const results = await Promise.allSettled(
+				itemsWithAgent.map((item) =>
+					api.subAgents.delete(
 						item.name,
 						item.agent,
 						item.source === "project" ? "project" : "global",
-					);
-				}),
+					),
+				),
 			);
+			const failures = results
+				.map((result, index) => ({
+					result,
+					item: itemsWithAgent[index],
+				}))
+				.filter(({ result }) => result.status === "rejected")
+				.map(({ item }) => ({ name: item.name, agent: item.agent }));
+			if (failures.length > 0) {
+				throw new BulkOperationError(failures);
+			}
 		},
 		onSuccess: async () => {
 			await invalidateSubAgentQueries(queryClient);
@@ -237,6 +253,15 @@ export default function SubAgentsPage() {
 			setPanel({ type: "empty" });
 		},
 		onError: (error) => {
+			if (error instanceof BulkOperationError) {
+				toast.danger(
+					t(
+						"bulkDeleteFailedItems",
+						bulkFailureItemsLabel(error.failures),
+					),
+				);
+				return;
+			}
 			toast.danger(
 				error instanceof Error
 					? error.message


### PR DESCRIPTION
## Background

Following up on #165 (bulk skill deletion). That PR fixed the universal-skill
duplicate DELETE problem and added a basic error toast, but the toast only said
\"N of M failed\" — users had no way to tell which items failed. Also, two
sub-agent bulk-delete paths shared neither the dedup nor the error handling.

## Changes

### 1. Detailed failure toast (\`feat(desktop)\`)

- New \`lib/bulk-errors.ts\` exporting:
  - \`BulkOperationError\` — typed error carrying the failed \`(name, agent)\` list
  - \`bulkFailureItemsLabel\` — formats up to 3 items + \"+N\" overflow
- \`BulkDeleteDialog\` throws \`BulkOperationError\` instead of a string, and
  \`onError\` renders the first 3 failures by name (annotated with their agent)
- New i18n key \`bulkDeleteFailedItems\` in en / zh-Hans / zh-Hant

### 2. Sub-agent bulk delete (\`fix(desktop)\`)

Two callsites previously used \`Promise.all\`, which loses every result the moment
a single delete rejects — and one of them (\`project/detail.tsx\`) had no error
handling at all, so rejections became unhandled promise rejections.

- Both call sites now use \`Promise.allSettled\`, collect failures, and surface
  them through the same \`bulkDeleteFailedItems\` toast
- Behavior parity with \`BulkDeleteDialog\`: a partial failure no longer pretends
  to be a full success

## Why a shared helper

Three call sites (and likely future ones for plugins / MCPs etc.) all need
the same \"name + agent, truncate at 3, +N overflow\" formatting. Rule of three
satisfied; helper lives in \`lib/bulk-errors.ts\`.

## Test plan

- [x] \`bunx tsc --noEmit\` in \`crates/desktop\` passes
- [ ] Manual: bulk-delete a mix of existing and missing skills; toast lists the missing ones by name and agent
- [ ] Manual: bulk-delete sub-agents in both settings and project pages; simulate a failure and confirm the toast shows the failing item
- [ ] Manual: bulk-delete > 3 failed items; toast shows \"first3, +N\"

## Stacked on top of

This branch is based on \`claude/funny-burnell-5cc708\` (#165). PR base should be
set accordingly until #165 lands, then this rebases onto main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bulk deletion failure reporting to display specific items and details that failed to delete, instead of generic error messages.
  * Added localized error messages in English, Simplified Chinese, and Traditional Chinese for bulk operation failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkaraChen/aghub/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->