### PR TITLE
fix(desktop): stop console windows flashing on Windows subprocess spawns

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -16,6 +16,9 @@ pub mod extractors;
 pub mod routes;
 pub mod state;
 
+#[cfg(windows)]
+pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 pub struct ApiOptions {
 	pub port: u16,
 	pub app_data_dir: Option<PathBuf>,

--- a/crates/api/src/routes/integrations.rs
+++ b/crates/api/src/routes/integrations.rs
@@ -38,7 +38,14 @@ pub async fn open_with_editor(
 	let req = request.into_inner();
 	let path = resolve_editor_path(&req.path);
 
-	match Command::new(req.editor.cli_command()).arg(&path).spawn() {
+	let mut cmd = Command::new(req.editor.cli_command());
+	cmd.arg(&path);
+	#[cfg(windows)]
+	{
+		use std::os::windows::process::CommandExt;
+		cmd.creation_flags(crate::CREATE_NO_WINDOW);
+	}
+	match cmd.spawn() {
 		Ok(_) => Ok(()),
 		Err(e) => Err(format!("Failed to open editor: {e}")),
 	}

--- a/crates/api/src/routes/plugins.rs
+++ b/crates/api/src/routes/plugins.rs
@@ -666,13 +666,17 @@ pub async fn open_plugin_skill_in_editor(
 	let id = parse_plugin_id(&req.plugin_id)?;
 	let (_, plugin) = load_manager_and_plugin(&id).await?;
 	let path = resolve_plugin_skill_path(&plugin, &req.scope, &req.skill_name)?;
-	Command::new(req.editor.cli_command())
-		.arg(&path)
-		.spawn()
-		.map_err(|e| {
-			error!("Failed to open plugin skill in editor: {e}");
-			ApiError::internal("Failed to open plugin skill in editor")
-		})?;
+	let mut cmd = Command::new(req.editor.cli_command());
+	cmd.arg(&path);
+	#[cfg(windows)]
+	{
+		use std::os::windows::process::CommandExt;
+		cmd.creation_flags(crate::CREATE_NO_WINDOW);
+	}
+	cmd.spawn().map_err(|e| {
+		error!("Failed to open plugin skill in editor: {e}");
+		ApiError::internal("Failed to open plugin skill in editor")
+	})?;
 	Ok(NoContent)
 }
 

--- a/crates/api/src/routes/skills.rs
+++ b/crates/api/src/routes/skills.rs
@@ -1013,10 +1013,14 @@ pub async fn edit_skill_folder(
 
 	match detect_available_editor() {
 		Some(editor) => {
-			match std::process::Command::new(editor.cli_command())
-				.arg(&folder)
-				.spawn()
+			let mut cmd = std::process::Command::new(editor.cli_command());
+			cmd.arg(&folder);
+			#[cfg(windows)]
 			{
+				use std::os::windows::process::CommandExt;
+				cmd.creation_flags(crate::CREATE_NO_WINDOW);
+			}
+			match cmd.spawn() {
 				Ok(_) => Ok(()),
 				Err(e) => Err(format!("Failed to open editor: {e}")),
 			}
@@ -1297,11 +1301,15 @@ pub async fn git_scan_skills(
 
 /// Try to detect the checked-out branch from the cloned repo.
 fn detect_current_branch(repo_path: &std::path::Path) -> Option<String> {
-	let output = std::process::Command::new("git")
-		.args(["rev-parse", "--abbrev-ref", "HEAD"])
-		.current_dir(repo_path)
-		.output()
-		.ok()?;
+	let mut cmd = std::process::Command::new("git");
+	cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
+		.current_dir(repo_path);
+	#[cfg(windows)]
+	{
+		use std::os::windows::process::CommandExt;
+		cmd.creation_flags(crate::CREATE_NO_WINDOW);
+	}
+	let output = cmd.output().ok()?;
 
 	if !output.status.success() {
 		return None;

--- a/crates/cc-plugins/src/cli/mod.rs
+++ b/crates/cc-plugins/src/cli/mod.rs
@@ -237,6 +237,8 @@ impl ClaudeCli {
 		let mut cmd = Command::new(&self.binary);
 		cmd.kill_on_drop(true);
 		cmd.args(args);
+		#[cfg(windows)]
+		cmd.creation_flags(crate::CREATE_NO_WINDOW);
 		let output = tokio::time::timeout(SPAWN_TIMEOUT, cmd.output())
 			.await
 			.with_context(|| format!("claude {} timed out", args.join(" ")))?

--- a/crates/cc-plugins/src/installer/registry.rs
+++ b/crates/cc-plugins/src/installer/registry.rs
@@ -83,6 +83,8 @@ pub(crate) async fn git_output(
 	let context = context.to_string();
 	let mut command = Command::new("git");
 	command.args(args);
+	#[cfg(windows)]
+	command.creation_flags(crate::CREATE_NO_WINDOW);
 	if let Some(path) = current_dir {
 		command.current_dir(path);
 	}
@@ -114,16 +116,14 @@ pub(crate) async fn git_clone(
 	context: &str,
 ) -> Result<()> {
 	let context = context.to_string();
-	let output = tokio::time::timeout(
-		GIT_COMMAND_TIMEOUT,
-		Command::new("git")
-			.args(["clone", "--depth", "1", source])
-			.arg(target)
-			.output(),
-	)
-	.await
-	.with_context(|| format!("{context} timed out"))?
-	.context(context)?;
+	let mut command = Command::new("git");
+	command.args(["clone", "--depth", "1", source]).arg(target);
+	#[cfg(windows)]
+	command.creation_flags(crate::CREATE_NO_WINDOW);
+	let output = tokio::time::timeout(GIT_COMMAND_TIMEOUT, command.output())
+		.await
+		.with_context(|| format!("{context} timed out"))?
+		.context(context)?;
 	if !output.status.success() {
 		let stderr = String::from_utf8_lossy(&output.stderr);
 		anyhow::bail!("Git clone failed: {}", stderr);

--- a/crates/cc-plugins/src/lib.rs
+++ b/crates/cc-plugins/src/lib.rs
@@ -15,6 +15,9 @@ pub(crate) const MANIFEST_CANDIDATE_PATHS: &[&str] = &[
 	"plugin.json",
 ];
 
+#[cfg(windows)]
+pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 pub mod errors {
 	use crate::PluginId;
 

--- a/crates/desktop/src-tauri/src/commands/logging.rs
+++ b/crates/desktop/src-tauri/src/commands/logging.rs
@@ -1,5 +1,7 @@
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 #[cfg(not(target_os = "linux"))]
 use std::process::Command;
@@ -37,6 +39,7 @@ fn os_version() -> String {
 	{
 		Command::new("cmd")
 			.args(["/C", "ver"])
+			.creation_flags(crate::CREATE_NO_WINDOW)
 			.output()
 			.ok()
 			.and_then(|o| String::from_utf8(o.stdout).ok())

--- a/crates/desktop/src-tauri/src/lib.rs
+++ b/crates/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,9 @@ use tauri_plugin_log::{
 
 mod commands;
 
+#[cfg(windows)]
+pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 pub struct AppState {
 	pub port: std::sync::Mutex<Option<u16>>,
 }


### PR DESCRIPTION
On Windows the GUI build (windows_subsystem = "windows") has no console of its own, so every console subprocess it spawns gets a fresh console window that flashes on screen. This fired throughout normal use: listing Claude Code plugins (claude CLI), refreshing the marketplace (git), opening a skill in an editor, and the diagnostics version probe (cmd /C ver).

- Set the CREATE_NO_WINDOW creation flag at each runtime spawn site:
  - aghub-cc-plugins: claude CLI (ClaudeCli::spawn) and git registry calls
  - aghub-api: editor launches and git branch detection
  - aghub-desktop: Windows version probe
- Define the flag once per crate; the calls are no-ops off Windows.

open::that() folder opening is unaffected (the open crate already sets the flag), and test-only git spawns are left as-is since tests run with a console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On Windows, external processes now run without displaying console windows, providing a cleaner user experience when opening editors, running Git operations, and executing system commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->