### PR TITLE
feat: add Windows tray and autostart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
@@ -53,7 +54,7 @@ name = "aghub-agents"
 version = "1.1.1"
 dependencies = [
  "aghub-markdown",
- "dirs",
+ "dirs 6.0.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -71,7 +72,7 @@ dependencies = [
  "aghub-core",
  "aghub-git",
  "aghub-inference",
- "dirs",
+ "dirs 6.0.0",
  "keyring",
  "log",
  "open",
@@ -97,7 +98,7 @@ dependencies = [
  "aghub-git",
  "anyhow",
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "log",
  "reqwest",
@@ -136,7 +137,7 @@ name = "aghub-core"
 version = "1.1.1"
 dependencies = [
  "aghub-agents",
- "dirs",
+ "dirs 6.0.0",
  "log",
  "serde",
  "serde_json",
@@ -164,7 +165,7 @@ name = "aghub-inference"
 version = "1.1.1"
 dependencies = [
  "aghub-json",
- "dirs",
+ "dirs 6.0.0",
  "keyring",
  "serde",
  "serde_json",
@@ -597,6 +598,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
 
 [[package]]
 name = "autocfg"
@@ -1673,11 +1685,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1688,7 +1720,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1845,7 +1877,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -6022,6 +6054,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -6952,7 +6995,7 @@ name = "skill"
 version = "1.1.1"
 dependencies = [
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "ignore",
  "serde",
  "serde_json",
@@ -7585,7 +7628,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -7635,7 +7678,7 @@ checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -7704,6 +7747,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7877,7 +7934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http 1.4.0",
@@ -8516,7 +8573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -9793,6 +9850,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -9923,7 +9989,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "posthog-rs",
  "serde",
  "serde_json",
+ "sys-locale",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -7485,6 +7486,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/desktop/bun.lock
+++ b/crates/desktop/bun.lock
@@ -15,6 +15,7 @@
         "@opentelemetry/sdk-logs": "^0.218.0",
         "@tanstack/react-query": "^5.100.14",
         "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/plugin-autostart": "2.5.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-deep-link": "^2.4.9",
         "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -677,6 +678,8 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
+
+    "@tauri-apps/plugin-autostart": ["@tauri-apps/plugin-autostart@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w=="],
 
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
 

--- a/crates/desktop/bun.lock
+++ b/crates/desktop/bun.lock
@@ -24,6 +24,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-store": "^2.4.3",
         "@tauri-apps/plugin-updater": "^2.10.1",
+        "bowser": "2.14.1",
         "clsx": "^2.1.1",
         "dotenv": "^17.0.0",
         "driver.js": "^1.4.0",
@@ -788,6 +789,8 @@
     "birecord": ["birecord@0.1.1", "", {}, "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 

--- a/crates/desktop/package.json
+++ b/crates/desktop/package.json
@@ -34,6 +34,7 @@
 		"@tauri-apps/plugin-process": "^2.3.1",
 		"@tauri-apps/plugin-store": "^2.4.3",
 		"@tauri-apps/plugin-updater": "^2.10.1",
+		"bowser": "2.14.1",
 		"clsx": "^2.1.1",
 		"dotenv": "^17.0.0",
 		"driver.js": "^1.4.0",

--- a/crates/desktop/package.json
+++ b/crates/desktop/package.json
@@ -25,6 +25,7 @@
 		"@opentelemetry/sdk-logs": "^0.218.0",
 		"@tanstack/react-query": "^5.100.14",
 		"@tauri-apps/api": "^2.11.0",
+		"@tauri-apps/plugin-autostart": "2.5.1",
 		"@tauri-apps/plugin-clipboard-manager": "^2.3.2",
 		"@tauri-apps/plugin-deep-link": "^2.4.9",
 		"@tauri-apps/plugin-dialog": "^2.7.1",

--- a/crates/desktop/src-tauri/Cargo.toml
+++ b/crates/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ dotenvy = "0.15.7"
 tauri-build = { version = "2", features = [  ] }
 
 [dependencies]
-tauri = { version = "2", features = [  ] }
+tauri = { version = "2", features = [ "tray-icon" ] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-deep-link = "2.4.7"
@@ -39,6 +39,7 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 posthog-rs = "0.7.0"
 uuid = { version = "1", features = [ "v4" ] }
 tauri-plugin-autostart = "2.5.1"
+sys-locale = "0.3.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/desktop/src-tauri/Cargo.toml
+++ b/crates/desktop/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ time = { version = "0.3", features = ["formatting", "local-offset"] }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 posthog-rs = "0.7.0"
 uuid = { version = "1", features = [ "v4" ] }
+tauri-plugin-autostart = "2.5.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/desktop/src-tauri/capabilities/default.json
+++ b/crates/desktop/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
 		"store:default",
 		"updater:default",
 		"process:default",
+		"autostart:default",
 		"clipboard-manager:allow-read-text",
 		"clipboard-manager:allow-write-text"
 	]

--- a/crates/desktop/src-tauri/src/commands/mod.rs
+++ b/crates/desktop/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod logging;
 pub mod posthog;
 pub mod server;
+pub mod window;
 
 pub use logging::{
 	clear_log_files, export_diagnostic_logs, get_log_dir_path, get_log_entries,
@@ -11,3 +12,4 @@ pub use posthog::{
 	posthog_get_session_id, posthog_identify, posthog_set_enabled,
 };
 pub use server::start_server;
+pub use window::minimize_to_tray;

--- a/crates/desktop/src-tauri/src/commands/window.rs
+++ b/crates/desktop/src-tauri/src/commands/window.rs
@@ -1,0 +1,20 @@
+use tauri::{AppHandle, Manager};
+
+#[tauri::command]
+pub async fn minimize_to_tray(app: AppHandle) -> Result<(), String> {
+	let Some(window) = app.get_webview_window("main") else {
+		return Ok(());
+	};
+
+	#[cfg(windows)]
+	{
+		window.hide().map_err(|error| error.to_string())?;
+	}
+
+	#[cfg(not(windows))]
+	{
+		window.minimize().map_err(|error| error.to_string())?;
+	}
+
+	Ok(())
+}

--- a/crates/desktop/src-tauri/src/lib.rs
+++ b/crates/desktop/src-tauri/src/lib.rs
@@ -63,6 +63,46 @@ fn focus_main_window(window: &WebviewWindow) {
 	let _ = window.set_focus();
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
+struct TrayText {
+	app_name: &'static str,
+	show: &'static str,
+	quit: &'static str,
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn localized_tray_text() -> TrayText {
+	let locale = sys_locale::get_locale()
+		.unwrap_or_default()
+		.replace('_', "-")
+		.to_ascii_lowercase();
+
+	if ["zh-hant", "zh-tw", "zh-hk", "zh-mo"]
+		.iter()
+		.any(|prefix| locale.starts_with(prefix))
+	{
+		return TrayText {
+			app_name: "aghub",
+			show: "顯示 aghub",
+			quit: "退出 aghub",
+		};
+	}
+
+	if locale.starts_with("zh") {
+		return TrayText {
+			app_name: "aghub",
+			show: "显示 aghub",
+			quit: "退出 aghub",
+		};
+	}
+
+	TrayText {
+		app_name: "aghub",
+		show: "Show aghub",
+		quit: "Quit aghub",
+	}
+}
+
 #[cfg(windows)]
 fn restore_main_window(app: &tauri::AppHandle) {
 	if let Some(window) = app.get_webview_window("main") {
@@ -80,16 +120,17 @@ fn setup_windows_tray(app: &mut tauri::App) -> tauri::Result<()> {
 	const SHOW_ID: &str = "show";
 	const QUIT_ID: &str = "quit";
 
+	let text = localized_tray_text();
 	let menu = MenuBuilder::new(app)
-		.text(SHOW_ID, "Show aghub")
+		.text(SHOW_ID, text.show)
 		.separator()
-		.text(QUIT_ID, "Quit")
+		.text(QUIT_ID, text.quit)
 		.build()?;
 
 	let mut tray = TrayIconBuilder::with_id("main")
 		.menu(&menu)
 		.show_menu_on_left_click(false)
-		.tooltip("aghub")
+		.tooltip(text.app_name)
 		.on_menu_event(|app, event| match event.id().as_ref() {
 			SHOW_ID => restore_main_window(app),
 			QUIT_ID => app.exit(0),

--- a/crates/desktop/src-tauri/src/lib.rs
+++ b/crates/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::commands::{
 	clear_log_files, export_diagnostic_logs, get_log_dir_path, get_log_entries,
-	get_log_stats, posthog_capture, posthog_get_config,
+	get_log_stats, minimize_to_tray, posthog_capture, posthog_get_config,
 	posthog_get_distinct_id, posthog_get_session_id, posthog_identify,
 	posthog_set_enabled, start_server,
 };
@@ -61,6 +61,58 @@ fn focus_main_window(window: &WebviewWindow) {
 	let _ = window.show();
 	let _ = window.unminimize();
 	let _ = window.set_focus();
+}
+
+#[cfg(windows)]
+fn restore_main_window(app: &tauri::AppHandle) {
+	if let Some(window) = app.get_webview_window("main") {
+		focus_main_window(&window);
+	}
+}
+
+#[cfg(windows)]
+fn setup_windows_tray(app: &mut tauri::App) -> tauri::Result<()> {
+	use tauri::{
+		menu::MenuBuilder,
+		tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
+	};
+
+	const SHOW_ID: &str = "show";
+	const QUIT_ID: &str = "quit";
+
+	let menu = MenuBuilder::new(app)
+		.text(SHOW_ID, "Show aghub")
+		.separator()
+		.text(QUIT_ID, "Quit")
+		.build()?;
+
+	let mut tray = TrayIconBuilder::with_id("main")
+		.menu(&menu)
+		.show_menu_on_left_click(false)
+		.tooltip("aghub")
+		.on_menu_event(|app, event| match event.id().as_ref() {
+			SHOW_ID => restore_main_window(app),
+			QUIT_ID => app.exit(0),
+			_ => {}
+		})
+		.on_tray_icon_event(|tray, event| {
+			if matches!(
+				event,
+				TrayIconEvent::DoubleClick {
+					button: MouseButton::Left,
+					..
+				}
+			) {
+				restore_main_window(tray.app_handle());
+			}
+		});
+
+	if let Some(icon) = app.default_window_icon().cloned() {
+		tray = tray.icon(icon);
+	}
+
+	tray.build(app)?;
+	Ok(())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -151,6 +203,23 @@ pub fn run() {
 		.plugin(tauri_plugin_opener::init())
 		.plugin(tauri_plugin_dialog::init())
 		.plugin(tauri_plugin_store::Builder::default().build())
+		.plugin(
+			tauri_plugin_autostart::Builder::new()
+				.arg("--minimized")
+				.build(),
+		)
+		.on_window_event(|window, event| {
+			#[cfg(windows)]
+			if window.label() == "main" {
+				if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+					api.prevent_close();
+					let _ = window.hide();
+				}
+			}
+
+			#[cfg(not(windows))]
+			let _ = (window, event);
+		})
 		.setup(|app| {
 			info!("aghub desktop application setup started");
 			#[cfg(desktop)]
@@ -180,6 +249,18 @@ pub fn run() {
 				}
 			}
 
+			#[cfg(windows)]
+			{
+				setup_windows_tray(app)?;
+				if std::env::args().any(|arg| arg == "--minimized") {
+					if let Some(window) =
+						app.handle().get_webview_window("main")
+					{
+						let _ = window.hide();
+					}
+				}
+			}
+
 			info!("aghub desktop setup completed");
 			Ok(())
 		})
@@ -196,6 +277,7 @@ pub fn run() {
 			posthog_get_distinct_id,
 			posthog_get_session_id,
 			posthog_set_enabled,
+			minimize_to_tray,
 		])
 		.run(tauri::generate_context!())
 		.expect("error while running tauri application");

--- a/crates/desktop/src/components/window-controls.tsx
+++ b/crates/desktop/src/components/window-controls.tsx
@@ -2,6 +2,7 @@ import { MinusIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState } from "react";
+import { isMacOS, isWindows } from "../lib/platform";
 
 function MaximizeIcon({ className }: { className?: string }) {
 	return (
@@ -40,10 +41,6 @@ function RestoreIcon({ className }: { className?: string }) {
 }
 
 export function WindowControls() {
-	const userAgent = navigator.userAgent.toLowerCase();
-	const isMac = userAgent.includes("mac");
-	const isWindows = userAgent.includes("windows");
-
 	const [isMaximized, setIsMaximized] = useState(false);
 	const [isTauri, setIsTauri] = useState(true);
 
@@ -69,7 +66,7 @@ export function WindowControls() {
 		};
 	}, []);
 
-	if (isMac || !isTauri) return null;
+	if (isMacOS() || !isTauri) return null;
 
 	return (
 		<div className="flex h-full items-stretch">
@@ -78,7 +75,7 @@ export function WindowControls() {
 				className="inline-flex w-12 cursor-default items-center justify-center text-muted transition-colors hover:bg-surface-secondary hover:text-foreground"
 				onClick={async () => {
 					try {
-						if (isWindows) {
+						if (isWindows()) {
 							await invoke("minimize_to_tray");
 						} else {
 							await getCurrentWindow().minimize();

--- a/crates/desktop/src/components/window-controls.tsx
+++ b/crates/desktop/src/components/window-controls.tsx
@@ -1,4 +1,5 @@
 import { MinusIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState } from "react";
 
@@ -39,7 +40,9 @@ function RestoreIcon({ className }: { className?: string }) {
 }
 
 export function WindowControls() {
-	const isMac = navigator.userAgent.toLowerCase().includes("mac");
+	const userAgent = navigator.userAgent.toLowerCase();
+	const isMac = userAgent.includes("mac");
+	const isWindows = userAgent.includes("windows");
 
 	const [isMaximized, setIsMaximized] = useState(false);
 	const [isTauri, setIsTauri] = useState(true);
@@ -75,7 +78,11 @@ export function WindowControls() {
 				className="inline-flex w-12 cursor-default items-center justify-center text-muted transition-colors hover:bg-surface-secondary hover:text-foreground"
 				onClick={async () => {
 					try {
-						await getCurrentWindow().minimize();
+						if (isWindows) {
+							await invoke("minimize_to_tray");
+						} else {
+							await getCurrentWindow().minimize();
+						}
 					} catch {}
 				}}
 				tabIndex={-1}

--- a/crates/desktop/src/layouts/main-layout.tsx
+++ b/crates/desktop/src/layouts/main-layout.tsx
@@ -1,10 +1,9 @@
 import { Surface } from "@heroui/react";
 import { AppSidebar } from "../components/app-sidebar";
 import { WindowControls } from "../components/window-controls";
+import { isMacOS } from "../lib/platform";
 
 export function MainLayout({ children }: { children: React.ReactNode }) {
-	const isMac = navigator.userAgent.toLowerCase().includes("mac");
-
 	return (
 		<Surface
 			variant="secondary"
@@ -15,7 +14,7 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
 				className="flex h-8 shrink-0 items-center justify-between border-b border-border pl-3"
 			>
 				<div className="pointer-events-none flex select-none items-center">
-					{!isMac && (
+					{!isMacOS() && (
 						<span className="text-xs font-medium tracking-wide text-foreground/50">
 							aghub
 						</span>

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -413,6 +413,13 @@ export default {
 	settingsAnalyticsDescription:
 		"Send anonymous usage data and crash reports to help improve aghub. Disabling this stops both event capture and session replay.",
 	settingsAnalyticsToggleLabel: "Share anonymous usage data",
+	settingsAutostartHeading: "Launch at startup",
+	settingsAutostartDescription:
+		"Start aghub automatically on Windows and keep it available from the system tray.",
+	settingsAutostartToggleLabel: "Launch aghub at Windows startup",
+	settingsAutostartEnabled: "Startup launch enabled",
+	settingsAutostartDisabled: "Startup launch disabled",
+	settingsAutostartError: "Failed to update startup launch",
 	onboardingSkip: "Skip",
 	onboardingBack: "Back",
 	onboardingNext: "Next",

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -396,6 +396,13 @@ export default {
 	settingsAnalyticsDescription:
 		"发送匿名使用数据和崩溃报告以帮助改进 aghub。关闭后将同时停止事件采集和会话回放。",
 	settingsAnalyticsToggleLabel: "分享匿名使用数据",
+	settingsAutostartHeading: "开机自启动",
+	settingsAutostartDescription:
+		"在 Windows 开机时自动启动 aghub，并保持在系统托盘可用。",
+	settingsAutostartToggleLabel: "Windows 开机时启动 aghub",
+	settingsAutostartEnabled: "已启用开机自启动",
+	settingsAutostartDisabled: "已关闭开机自启动",
+	settingsAutostartError: "更新开机自启动失败",
 	onboardingSkip: "跳过",
 	onboardingBack: "返回",
 	onboardingNext: "下一步",

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -395,6 +395,13 @@ export default {
 	settingsAnalyticsDescription:
 		"傳送匿名使用資料和當機回報以協助改進 aghub。關閉後將同時停止事件擷取和工作階段重播。",
 	settingsAnalyticsToggleLabel: "分享匿名使用資料",
+	settingsAutostartHeading: "開機自動啟動",
+	settingsAutostartDescription:
+		"在 Windows 開機時自動啟動 aghub，並保持在系統托盤可用。",
+	settingsAutostartToggleLabel: "Windows 開機時啟動 aghub",
+	settingsAutostartEnabled: "已啟用開機自動啟動",
+	settingsAutostartDisabled: "已關閉開機自動啟動",
+	settingsAutostartError: "更新開機自動啟動失敗",
 	onboardingSkip: "跳過",
 	onboardingBack: "返回",
 	onboardingNext: "下一步",

--- a/crates/desktop/src/lib/menu.ts
+++ b/crates/desktop/src/lib/menu.ts
@@ -6,6 +6,7 @@ import {
 	Submenu,
 } from "@tauri-apps/api/menu";
 import type { TFunction } from "i18next";
+import { isMacOS } from "./platform";
 
 let activeAppMenu: Menu | null = null;
 
@@ -160,8 +161,7 @@ export async function setupAppMenu(t: TFunction) {
 			items: [appSubmenu, agentSubmenu, editSubmenu, controlSubmenu],
 		});
 
-		const isMac = navigator.userAgent.toLowerCase().includes("mac");
-		if (isMac) {
+		if (isMacOS()) {
 			await activeAppMenu.setAsAppMenu();
 		}
 	} catch (e) {

--- a/crates/desktop/src/lib/platform.ts
+++ b/crates/desktop/src/lib/platform.ts
@@ -1,0 +1,16 @@
+import Bowser from "bowser";
+
+let osName: string | null = null;
+
+function getOSName(): string {
+	osName ??= Bowser.getParser(navigator.userAgent).getOSName(true);
+	return osName;
+}
+
+export function isMacOS(): boolean {
+	return getOSName() === "macos";
+}
+
+export function isWindows(): boolean {
+	return getOSName() === "windows";
+}

--- a/crates/desktop/src/pages/settings/application-panel.tsx
+++ b/crates/desktop/src/pages/settings/application-panel.tsx
@@ -1,6 +1,11 @@
 import { Avatar, Button, Card, Switch, toast } from "@heroui/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getName, getVersion } from "@tauri-apps/api/app";
+import {
+	disable as disableAutostart,
+	enable as enableAutostart,
+	isEnabled as isAutostartEnabled,
+} from "@tauri-apps/plugin-autostart";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
@@ -12,6 +17,7 @@ import { getAnalyticsConsent, setAnalyticsConsent } from "../../lib/store";
 export default function ApplicationPanel() {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
+	const isWindows = navigator.userAgent.toLowerCase().includes("windows");
 
 	const { data: appInfo } = useQuery({
 		queryKey: ["app-info"],
@@ -27,6 +33,13 @@ export default function ApplicationPanel() {
 		queryFn: getAnalyticsConsent,
 	});
 	const analyticsEnabled = analyticsConsent !== "denied";
+
+	const { data: autostartEnabled = false, isPending: isAutostartLoading } =
+		useQuery({
+			queryKey: ["windows-autostart"],
+			queryFn: isAutostartEnabled,
+			enabled: isWindows,
+		});
 
 	const analyticsMutation = useMutation({
 		mutationFn: async (enabled: boolean) => {
@@ -44,6 +57,34 @@ export default function ApplicationPanel() {
 				error instanceof Error
 					? error.message
 					: "Failed to update analytics consent",
+			);
+		},
+	});
+
+	const autostartMutation = useMutation({
+		mutationFn: async (enabled: boolean) => {
+			if (enabled) {
+				await enableAutostart();
+			} else {
+				await disableAutostart();
+			}
+			return enabled;
+		},
+		onSuccess: (enabled) => {
+			queryClient.invalidateQueries({
+				queryKey: ["windows-autostart"],
+			});
+			toast.success(
+				enabled
+					? t("settingsAutostartEnabled")
+					: t("settingsAutostartDisabled"),
+			);
+		},
+		onError: (error) => {
+			toast.danger(
+				error instanceof Error
+					? error.message
+					: t("settingsAutostartError"),
 			);
 		},
 	});
@@ -234,6 +275,34 @@ export default function ApplicationPanel() {
 							</Switch.Control>
 						</Switch>
 					</div>
+
+					{isWindows ? (
+						<div className="flex items-center justify-between gap-4">
+							<div className="space-y-0.5">
+								<span className="text-sm font-medium text-(--foreground)">
+									{t("settingsAutostartHeading")}
+								</span>
+								<span className="block text-xs text-muted">
+									{t("settingsAutostartDescription")}
+								</span>
+							</div>
+							<Switch
+								isSelected={autostartEnabled}
+								onChange={(checked) =>
+									autostartMutation.mutate(checked)
+								}
+								isDisabled={
+									isAutostartLoading ||
+									autostartMutation.isPending
+								}
+								aria-label={t("settingsAutostartToggleLabel")}
+							>
+								<Switch.Control>
+									<Switch.Thumb />
+								</Switch.Control>
+							</Switch>
+						</div>
+					) : null}
 
 					<div className="flex items-center justify-between">
 						<div className="space-y-0.5">

--- a/crates/desktop/src/pages/settings/application-panel.tsx
+++ b/crates/desktop/src/pages/settings/application-panel.tsx
@@ -12,12 +12,13 @@ import { check } from "@tauri-apps/plugin-updater";
 import { useTranslation } from "react-i18next";
 import { applyAnalyticsConsent } from "../../lib/analytics";
 import { dispatchOnboardingCommand } from "../../lib/onboarding";
+import { isWindows } from "../../lib/platform";
 import { getAnalyticsConsent, setAnalyticsConsent } from "../../lib/store";
 
 export default function ApplicationPanel() {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
-	const isWindows = navigator.userAgent.toLowerCase().includes("windows");
+	const isWindowsOS = isWindows();
 
 	const { data: appInfo } = useQuery({
 		queryKey: ["app-info"],
@@ -38,7 +39,7 @@ export default function ApplicationPanel() {
 		useQuery({
 			queryKey: ["windows-autostart"],
 			queryFn: isAutostartEnabled,
-			enabled: isWindows,
+			enabled: isWindowsOS,
 		});
 
 	const analyticsMutation = useMutation({
@@ -276,7 +277,7 @@ export default function ApplicationPanel() {
 						</Switch>
 					</div>
 
-					{isWindows ? (
+					{isWindowsOS ? (
 						<div className="flex items-center justify-between gap-4">
 							<div className="space-y-0.5">
 								<span className="text-sm font-medium text-(--foreground)">


### PR DESCRIPTION
## Summary
- add Windows system tray support with Show/Quit menu actions and double-click restore
- hide the main window to tray on Windows close requests and custom minimize button clicks
- add a Windows-only settings toggle for launch-at-startup using Tauri's autostart plugin

## Issues
Closes #195
Closes #196

## Verification
- `bun run typecheck`
- `cargo check -p aghub`
- `cargo clippy -p aghub -- -D warnings`
- `bun run build`

Attempted `cargo check -p aghub --target x86_64-pc-windows-msvc`, but this macOS machine is missing Windows SDK headers (`windows.h` / `stdlib.h`) required by `aws-lc-sys`, so that cross-target check could not complete locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable "Launch at startup" setting for Windows users
  * Implemented minimize-to-tray functionality on Windows platform, allowing the app to minimize to the system tray instead of closing
  * New autostart settings panel added to application preferences with enable/disable toggle and status indicators

* **Localization**
  * Added Simplified and Traditional Chinese translations for new autostart features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->