### PR TITLE
fix(desktop): avoid hidden Windows API runtime

### DIFF
--- a/crates/desktop/src-tauri/src/lib.rs
+++ b/crates/desktop/src-tauri/src/lib.rs
@@ -244,23 +244,7 @@ pub fn run() {
 		.plugin(tauri_plugin_opener::init())
 		.plugin(tauri_plugin_dialog::init())
 		.plugin(tauri_plugin_store::Builder::default().build())
-		.plugin(
-			tauri_plugin_autostart::Builder::new()
-				.arg("--minimized")
-				.build(),
-		)
-		.on_window_event(|window, event| {
-			#[cfg(windows)]
-			if window.label() == "main" {
-				if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-					api.prevent_close();
-					let _ = window.hide();
-				}
-			}
-
-			#[cfg(not(windows))]
-			let _ = (window, event);
-		})
+		.plugin(tauri_plugin_autostart::Builder::new().build())
 		.setup(|app| {
 			info!("aghub desktop application setup started");
 			#[cfg(desktop)]
@@ -291,16 +275,7 @@ pub fn run() {
 			}
 
 			#[cfg(windows)]
-			{
-				setup_windows_tray(app)?;
-				if std::env::args().any(|arg| arg == "--minimized") {
-					if let Some(window) =
-						app.handle().get_webview_window("main")
-					{
-						let _ = window.hide();
-					}
-				}
-			}
+			setup_windows_tray(app)?;
 
 			info!("aghub desktop setup completed");
 			Ok(())


### PR DESCRIPTION
### Motivation
- The Windows build previously intercepted the main window close event and hid the window instead of exiting, allowing the embedded unauthenticated localhost API to continue running while the UI appeared closed. 
- Autostart was registering a `--minimized` argument and the app hid the window at startup, which extended the time the API remained reachable without explicit user consent. 
- The change removes the hidden/persistent runtime behavior while preserving explicit tray/minimize-to-tray functionality so user intent maps to process lifetime.

### Description
- Removed the unconditional `tauri_plugin_autostart` registration that passed `--minimized` and the code-path that hid the main window on startup, replacing it with a plain `tauri_plugin_autostart::Builder::new().build()` invocation in `crates/desktop/src-tauri/src/lib.rs`. 
- Deleted the Windows `on_window_event` handler that called `api.prevent_close()` and `window.hide()` for the `CloseRequested` event so closing the main window will now exit as expected. 
- Removed the runtime check that hid the main window when `std::env::args()` contained `--minimized`, while leaving `setup_windows_tray` and the explicit `minimize_to_tray` command intact. 
- Changes are limited to `crates/desktop/src-tauri/src/lib.rs` and do not alter the embedded API behavior or server routes themselves.

### Testing
- Ran code formatting check with `cargo fmt --package aghub --check`, which completed successfully. 
- Verified there are no diff error markers with `git diff --check`, which passed. 
- Searched the desktop sources with `rg -n "CloseRequested|prevent_close|--minimized|\.arg\(\"--minimized\"\)|std::env::args\(\).*minimized|window\.hide\(\)"` to confirm removal, which returned no remaining matches in the modified files. 
- Attempts to run `RUSTC_WRAPPER= cargo check -p aghub` failed due to external crate download/network errors (crates.io CONNECT tunnel 403), and `cargo check --offline` failed because required dependencies were not cached locally, so full build verification was blocked by the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb54d3ec483298f8662fdc2a31f66)