### PR TITLE
fix(desktop): isolate provider SVG icons

### DIFF
--- a/crates/desktop/src/pages/inference-providers.tsx
+++ b/crates/desktop/src/pages/inference-providers.tsx
@@ -192,16 +192,14 @@ function ProviderFormatIcon({
 	className?: string;
 }) {
 	const svg = format === "anthropic" ? anthropicLogo : openAiLogo;
+	const svgDataUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 
 	return (
-		<span
-			className={cn(
-				"size-4 shrink-0 text-foreground [&>svg]:size-full",
-				className,
-			)}
+		<img
+			alt=""
+			className={cn("size-4 shrink-0 dark:invert", className)}
 			aria-hidden
-			// eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml
-			dangerouslySetInnerHTML={{ __html: svg }}
+			src={svgDataUrl}
 		/>
 	);
 }


### PR DESCRIPTION
### Motivation
- Prevent injection of third-party raw SVG markup into the Tauri webview DOM (previous `dangerouslySetInnerHTML` sink) by restoring an isolated rendering pattern that keeps active SVG content out of the page context.

### Description
- In `crates/desktop/src/pages/inference-providers.tsx` replace the `ProviderFormatIcon` inline SVG sink with an encoded data URL and render via an `<img>` (`const svgDataUrl = \`data:image/svg+xml;utf8,${encodeURIComponent(svg)}\`` and `src={svgDataUrl}`), removing `dangerouslySetInnerHTML`.

### Testing
- Ran `git diff --check` which passed.
- Executed a static assertion script that verified `dangerouslySetInnerHTML` was removed and that `ProviderFormatIcon` now uses an encoded SVG data URL in an `<img>` (succeeded).
- `cd crates/desktop && bun install --frozen-lockfile` and `cd crates/desktop && bun run typecheck` were attempted but blocked by the environment (npm registry `403`), so full typecheck/build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb8cf298c8329bdbb39a65ac5e2c2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the rendering implementation for inference provider format icons to enhance code maintainability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->