### PR TITLE
fix(api): require token for plugin mutations

### DIFF
--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -5,12 +5,13 @@ use rocket::response::{self, Responder};
 use rocket::serde::json::serde_json;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct ErrorBody {
 	pub error: String,
 	pub code: &'static str,
 }
 
+#[derive(Debug)]
 pub struct ApiError {
 	pub status: Status,
 	pub body: ErrorBody,

--- a/crates/api/src/extractors.rs
+++ b/crates/api/src/extractors.rs
@@ -1,10 +1,44 @@
 use aghub_core::models::AgentType;
 use aghub_core::paths::find_project_root;
 use rocket::http::Status;
-use rocket::request::FromParam;
+use rocket::request::{FromParam, FromRequest, Outcome};
 use std::path::PathBuf;
 
 use crate::error::ApiError;
+
+pub const API_TOKEN_HEADER: &str = "X-AGHUB-API-TOKEN";
+
+pub struct ApiAuthToken(pub String);
+
+pub struct ApiToken;
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ApiToken {
+	type Error = ApiError;
+
+	async fn from_request(
+		request: &'r rocket::Request<'_>,
+	) -> Outcome<Self, Self::Error> {
+		let Some(expected) = request.rocket().state::<ApiAuthToken>() else {
+			return Outcome::Error((
+				Status::InternalServerError,
+				ApiError::internal("API auth token is not configured"),
+			));
+		};
+		let provided = request.headers().get_one(API_TOKEN_HEADER);
+		if provided.is_some_and(|token| token == expected.0) {
+			return Outcome::Success(ApiToken);
+		}
+		Outcome::Error((
+			Status::Unauthorized,
+			ApiError::new(
+				Status::Unauthorized,
+				"Missing or invalid API token",
+				"UNAUTHORIZED",
+			),
+		))
+	}
+}
 
 pub struct AgentParam(pub AgentType);
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 pub struct ApiOptions {
 	pub port: u16,
 	pub app_data_dir: Option<PathBuf>,
+	pub auth_token: Option<String>,
 }
 
 impl ApiOptions {
@@ -29,6 +30,9 @@ impl ApiOptions {
 		Self {
 			port,
 			app_data_dir: None,
+			auth_token: std::env::var("AGHUB_API_TOKEN")
+				.ok()
+				.filter(|token| !token.is_empty()),
 		}
 	}
 }
@@ -92,6 +96,7 @@ impl Fairing for ApiLogFairing {
 fn build_rocket(
 	config: rocket::Config,
 	app_data_dir: PathBuf,
+	auth_token: String,
 ) -> rocket::Rocket<rocket::Build> {
 	let cors = rocket_cors::CorsOptions {
 		allowed_origins: rocket_cors::AllOrSome::All,
@@ -109,6 +114,7 @@ fn build_rocket(
 			"Authorization",
 			"Accept",
 			"Content-Type",
+			crate::extractors::API_TOKEN_HEADER,
 		]),
 		allow_credentials: true,
 		..Default::default()
@@ -122,6 +128,7 @@ fn build_rocket(
 			sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
 		})
 		.manage(crate::state::InferenceProviderState { app_data_dir })
+		.manage(crate::extractors::ApiAuthToken(auth_token))
 		.mount(
 			"/api/v1",
 			routes![
@@ -239,13 +246,20 @@ pub async fn start(options: ApiOptions) -> Result<(), rocket::Error> {
 	info!("starting aghub API server on 127.0.0.1:{}", options.port);
 	let app_data_dir =
 		options.app_data_dir.unwrap_or_else(default_app_data_dir);
+	let (auth_token, generated_auth_token) = match options.auth_token {
+		Some(token) => (token, false),
+		None => (uuid::Uuid::new_v4().to_string(), true),
+	};
+	if generated_auth_token {
+		eprintln!("aghub API token: {auth_token}");
+	}
 	let config = rocket::Config {
 		port: options.port,
 		address: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
 		log_level: rocket::config::LogLevel::Normal,
 		..rocket::Config::default()
 	};
-	build_rocket(config, app_data_dir)
+	build_rocket(config, app_data_dir, auth_token)
 		.launch()
 		.await
 		.inspect(|_rocket| {
@@ -261,6 +275,7 @@ pub async fn start(options: ApiOptions) -> Result<(), rocket::Error> {
 #[cfg(test)]
 mod tests {
 	use super::{build_rocket, default_app_data_dir};
+	use crate::extractors::API_TOKEN_HEADER;
 	use rocket::http::{Header, Status};
 	use rocket::local::blocking::Client;
 
@@ -269,6 +284,7 @@ mod tests {
 		let client = Client::tracked(build_rocket(
 			rocket::Config::default(),
 			default_app_data_dir(),
+			"test-token".to_string(),
 		))
 		.expect("client");
 
@@ -279,7 +295,7 @@ mod tests {
 			.header(Header::new("Access-Control-Request-Method", "POST"))
 			.header(Header::new(
 				"Access-Control-Request-Headers",
-				"content-type",
+				format!("content-type, {API_TOKEN_HEADER}"),
 			))
 			.dispatch();
 
@@ -288,9 +304,31 @@ mod tests {
 			response.headers().get_one("Access-Control-Allow-Origin"),
 			Some("http://localhost:1420"),
 		);
-		assert_eq!(
-			response.headers().get_one("Access-Control-Allow-Headers"),
-			Some("content-type"),
-		);
+		let allow_headers = response
+			.headers()
+			.get_one("Access-Control-Allow-Headers")
+			.unwrap_or_default()
+			.to_ascii_lowercase();
+		assert!(allow_headers.contains("content-type"));
+		assert!(allow_headers.contains(&API_TOKEN_HEADER.to_ascii_lowercase()));
+	}
+
+	#[test]
+	fn plugin_marketplace_add_requires_api_token() {
+		let client = Client::tracked(build_rocket(
+			rocket::Config::default(),
+			default_app_data_dir(),
+			"test-token".to_string(),
+		))
+		.expect("client");
+
+		let response = client
+			.post("/api/v1/plugins/marketplaces")
+			.header(Header::new("Origin", "http://localhost:1420"))
+			.header(Header::new("Content-Type", "application/json"))
+			.body(r#"{"source":"attacker/repo","scope":"user","sparse":[]}"#)
+			.dispatch();
+
+		assert_eq!(response.status(), Status::Unauthorized);
 	}
 }

--- a/crates/api/src/routes/plugins.rs
+++ b/crates/api/src/routes/plugins.rs
@@ -16,6 +16,7 @@ use crate::dto::plugin::{
 	CCPluginValidateResponse,
 };
 use crate::error::{ApiError, ApiNoContent, ApiResult};
+use crate::extractors::ApiToken;
 use aghub_cc_plugins::claude::settings::InstallScope;
 use aghub_cc_plugins::claude::{ClaudePluginInfo, ClaudePluginManager};
 use aghub_cc_plugins::cli::types::{CliMarketplace, CliMarketplaceSource};
@@ -288,6 +289,7 @@ pub async fn list_plugins() -> ApiResult<CCPluginListResponse> {
 
 #[post("/plugins/enable?<plugin_id>&<scope>")]
 pub async fn enable_plugin(
+	_auth: ApiToken,
 	plugin_id: &str,
 	scope: Option<&str>,
 ) -> ApiResult<CCPluginResponse> {
@@ -310,6 +312,7 @@ pub async fn enable_plugin(
 
 #[post("/plugins/disable?<plugin_id>&<scope>")]
 pub async fn disable_plugin(
+	_auth: ApiToken,
 	plugin_id: &str,
 	scope: Option<&str>,
 ) -> ApiResult<CCPluginResponse> {
@@ -334,6 +337,7 @@ pub async fn disable_plugin(
 
 #[post("/plugins/install", data = "<body>")]
 pub async fn install_plugin(
+	_auth: ApiToken,
 	body: Json<CCPluginInstallRequest>,
 ) -> ApiResult<CCPluginInstallResponse> {
 	let req = body.into_inner();
@@ -372,6 +376,7 @@ pub async fn install_plugin(
 
 #[post("/plugins/uninstall", data = "<body>")]
 pub async fn uninstall_plugin(
+	_auth: ApiToken,
 	body: Json<CCPluginUninstallRequest>,
 ) -> ApiResult<CCPluginUninstallResponse> {
 	let req = body.into_inner();
@@ -399,6 +404,7 @@ pub async fn uninstall_plugin(
 
 #[post("/plugins/update", data = "<body>")]
 pub async fn update_plugin(
+	_auth: ApiToken,
 	body: Json<CCPluginUpdateRequest>,
 ) -> ApiResult<CCPluginUpdateResponse> {
 	let req = body.into_inner();
@@ -580,6 +586,7 @@ pub async fn get_plugin_config(
 
 #[post("/plugins/config", data = "<body>")]
 pub async fn update_plugin_config(
+	_auth: ApiToken,
 	body: Json<CCPluginUpdateConfigRequest>,
 ) -> ApiResult<CCPluginConfigResponse> {
 	let req = body.into_inner();
@@ -617,6 +624,7 @@ pub async fn update_plugin_config(
 
 #[delete("/plugins/config?<plugin_id>")]
 pub async fn delete_plugin_config(
+	_auth: ApiToken,
 	plugin_id: String,
 ) -> ApiResult<CCPluginConfigResponse> {
 	let id = parse_plugin_id(&plugin_id)?;
@@ -643,6 +651,7 @@ pub async fn delete_plugin_config(
 
 #[post("/plugins/open-folder?<plugin_id>&<scope>")]
 pub async fn open_plugin_folder(
+	_auth: ApiToken,
 	plugin_id: &str,
 	scope: Option<&str>,
 ) -> ApiNoContent {
@@ -660,6 +669,7 @@ pub async fn open_plugin_folder(
 
 #[post("/plugins/open-skill-in-editor", data = "<body>")]
 pub async fn open_plugin_skill_in_editor(
+	_auth: ApiToken,
 	body: Json<CCPluginOpenSkillInEditorRequest>,
 ) -> ApiNoContent {
 	let req = body.into_inner();
@@ -845,6 +855,7 @@ pub async fn list_marketplaces() -> ApiResult<CCMarketplaceListResponse> {
 
 #[post("/plugins/marketplaces", data = "<body>")]
 pub async fn add_marketplace(
+	_auth: ApiToken,
 	body: Json<CCMarketplaceAddRequest>,
 ) -> ApiResult<CCMarketplaceMutationResponse> {
 	let req = body.into_inner();
@@ -871,6 +882,7 @@ pub async fn add_marketplace(
 
 #[delete("/plugins/marketplaces/<name>")]
 pub async fn remove_marketplace(
+	_auth: ApiToken,
 	name: &str,
 ) -> ApiResult<CCMarketplaceMutationResponse> {
 	let cli = load_claude_cli()?;
@@ -891,6 +903,7 @@ pub async fn remove_marketplace(
 
 #[post("/plugins/marketplaces/<name>/update")]
 pub async fn update_marketplace_one(
+	_auth: ApiToken,
 	name: &str,
 ) -> ApiResult<CCMarketplaceMutationResponse> {
 	let cli = load_claude_cli()?;
@@ -927,7 +940,9 @@ pub async fn update_marketplace_one(
 }
 
 #[post("/plugins-market/update")]
-pub async fn update_marketplace() -> ApiResult<serde_json::Value> {
+pub async fn update_marketplace(
+	_auth: ApiToken,
+) -> ApiResult<serde_json::Value> {
 	let installer = load_plugin_installer()?;
 	let updated = tokio::time::timeout(
 		PLUGIN_MARKET_UPDATE_TIMEOUT,
@@ -960,6 +975,7 @@ pub async fn update_marketplace() -> ApiResult<serde_json::Value> {
 
 #[post("/plugins/prune", data = "<body>")]
 pub async fn prune_plugins(
+	_auth: ApiToken,
 	body: Json<CCPluginPruneRequest>,
 ) -> ApiResult<CCPluginPruneResponse> {
 	let req = body.into_inner();
@@ -981,6 +997,7 @@ pub async fn prune_plugins(
 
 #[post("/plugins/validate", data = "<body>")]
 pub async fn validate_plugin(
+	_auth: ApiToken,
 	body: Json<CCPluginValidateRequest>,
 ) -> ApiResult<CCPluginValidateResponse> {
 	let req = body.into_inner();

--- a/crates/desktop/src-tauri/src/commands/server.rs
+++ b/crates/desktop/src-tauri/src/commands/server.rs
@@ -1,7 +1,14 @@
 use crate::AppState;
 use aghub_api::{start, ApiOptions};
 use log::{debug, error, info};
+use serde::Serialize;
 use tauri::Manager;
+
+#[derive(Clone, Serialize)]
+pub struct ServerInfo {
+	pub port: u16,
+	pub auth_token: String,
+}
 
 fn find_available_port() -> Result<u16, String> {
 	let listener = std::net::TcpListener::bind("127.0.0.1:0")
@@ -14,32 +21,41 @@ fn find_available_port() -> Result<u16, String> {
 pub async fn start_server(
 	state: tauri::State<'_, AppState>,
 	app: tauri::AppHandle,
-) -> Result<u16, String> {
+) -> Result<ServerInfo, String> {
 	let app_data_dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
-	let port = {
-		let mut guard = state.port.lock().unwrap();
-		if let Some(port) = *guard {
-			debug!("reusing embedded API server port {port}");
-			return Ok(port);
+	let server = {
+		let mut guard = state.server.lock().unwrap();
+		if let Some(server) = guard.clone() {
+			debug!("reusing embedded API server port {}", server.port);
+			return Ok(server);
 		}
 
-		let port = find_available_port()?;
-		*guard = Some(port);
-		debug!("stored embedded API server port {port} in application state");
-		port
+		let server = ServerInfo {
+			port: find_available_port()?,
+			auth_token: uuid::Uuid::new_v4().to_string(),
+		};
+		*guard = Some(server.clone());
+		debug!(
+			"stored embedded API server port {} in application state",
+			server.port
+		);
+		server
 	};
 
+	let port = server.port;
+	let auth_token = server.auth_token.clone();
 	info!("received request to start embedded API server on port {port}");
 	tokio::spawn(async move {
 		info!("starting embedded API server on 127.0.0.1:{port}");
 		if let Err(error) = start(ApiOptions {
 			port,
 			app_data_dir: Some(app_data_dir),
+			auth_token: Some(auth_token),
 		})
 		.await
 		{
 			error!("embedded API server exited with error: {error}");
 		}
 	});
-	Ok(port)
+	Ok(server)
 }

--- a/crates/desktop/src-tauri/src/lib.rs
+++ b/crates/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,8 @@ use crate::commands::{
 };
 use log::info;
 use tauri::{Manager, WebviewWindow};
+
+use crate::commands::server::ServerInfo;
 use tauri_plugin_log::fern::colors::{Color, ColoredLevelConfig};
 use tauri_plugin_log::{
 	RotationStrategy, Target, TargetKind, TimezoneStrategy,
@@ -17,7 +19,7 @@ mod commands;
 pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 pub struct AppState {
-	pub port: std::sync::Mutex<Option<u16>>,
+	pub server: std::sync::Mutex<Option<ServerInfo>>,
 }
 
 fn default_log_config() -> commands::logging::LogConfig {
@@ -232,7 +234,7 @@ pub fn run() {
 				.build(),
 		)
 		.manage(AppState {
-			port: std::sync::Mutex::new(None),
+			server: std::sync::Mutex::new(None),
 		})
 		.plugin(tauri_plugin_deep_link::init())
 		.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {

--- a/crates/desktop/src/contexts/server.tsx
+++ b/crates/desktop/src/contexts/server.tsx
@@ -4,6 +4,7 @@ import { createContext, use } from "react";
 export interface ServerContextValue {
 	port: number;
 	baseUrl: string;
+	authToken: string;
 }
 
 export const ServerContext = createContext<ServerContextValue | null>(null);

--- a/crates/desktop/src/hooks/use-api.ts
+++ b/crates/desktop/src/hooks/use-api.ts
@@ -3,7 +3,10 @@ import { getApiClient } from "../requests/client";
 import { useServer } from "./use-server";
 
 export function useApi() {
-	const { baseUrl } = useServer();
+	const { authToken, baseUrl } = useServer();
 
-	return useMemo(() => getApiClient(baseUrl), [baseUrl]);
+	return useMemo(
+		() => getApiClient(baseUrl, authToken),
+		[baseUrl, authToken],
+	);
 }

--- a/crates/desktop/src/lib/api.ts
+++ b/crates/desktop/src/lib/api.ts
@@ -72,9 +72,12 @@ interface ApiErrorBody {
 	code?: string;
 }
 
-export function createApi(baseUrl: string) {
+export function createApi(baseUrl: string, authToken: string) {
 	const client = ky.create({
 		prefix: baseUrl,
+		headers: {
+			"X-AGHUB-API-TOKEN": authToken,
+		},
 		hooks: {
 			beforeError: [
 				async ({ error }) => {

--- a/crates/desktop/src/providers/server.tsx
+++ b/crates/desktop/src/providers/server.tsx
@@ -5,15 +5,20 @@ import { useEffect, useState } from "react";
 import type { ServerProviderProps } from "../contexts/server";
 import { ServerContext } from "../contexts/server";
 
+interface ServerInfo {
+	port: number;
+	auth_token: string;
+}
+
 export function ServerProvider({ children }: ServerProviderProps) {
-	const [port, setPort] = useState<number | null>(null);
+	const [server, setServer] = useState<ServerInfo | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		invoke<number>("start_server")
+		invoke<ServerInfo>("start_server")
 			.then((value) => {
-				void info(`Desktop API server started on port ${value}`);
-				setPort(value);
+				void info(`Desktop API server started on port ${value.port}`);
+				setServer(value);
 			})
 			.catch((e) => {
 				console.error("Failed to start desktop API server:", e);
@@ -31,7 +36,7 @@ export function ServerProvider({ children }: ServerProviderProps) {
 		);
 	}
 
-	if (port === null) {
+	if (server === null) {
 		return (
 			<div className="flex h-screen items-center justify-center">
 				<Spinner size="lg" />
@@ -41,7 +46,11 @@ export function ServerProvider({ children }: ServerProviderProps) {
 
 	return (
 		<ServerContext
-			value={{ port, baseUrl: `http://localhost:${port}/api/v1` }}
+			value={{
+				port: server.port,
+				baseUrl: `http://localhost:${server.port}/api/v1`,
+				authToken: server.auth_token,
+			}}
 		>
 			{children}
 		</ServerContext>

--- a/crates/desktop/src/requests/client.ts
+++ b/crates/desktop/src/requests/client.ts
@@ -4,14 +4,15 @@ export type ApiClient = ReturnType<typeof createApi>;
 
 const clients = new Map<string, ApiClient>();
 
-export function getApiClient(baseUrl: string): ApiClient {
-	const existing = clients.get(baseUrl);
+export function getApiClient(baseUrl: string, authToken: string): ApiClient {
+	const key = `${baseUrl}:${authToken}`;
+	const existing = clients.get(key);
 
 	if (existing) {
 		return existing;
 	}
 
-	const client = createApi(baseUrl);
-	clients.set(baseUrl, client);
+	const client = createApi(baseUrl, authToken);
+	clients.set(key, client);
 	return client;
 }


### PR DESCRIPTION
### Motivation

- Close an unauthenticated attack surface that allowed adding/removing Claude plugin marketplaces and installing plugins via the localhost API by enforcing an API token for mutation routes.
- Ensure the embedded desktop server still works by providing a secure short-lived token to the local frontend while keeping the standalone CLI-compatible invocation path.

### Description

- Add an `ApiToken` request guard and `ApiAuthToken` Rocket state that validate the `X-AGHUB-API-TOKEN` header and surface a clear `UNAUTHORIZED` error when missing or invalid, implemented in `crates/api/src/extractors.rs`.
- Wire token support into API startup: `ApiOptions` reads `AGHUB_API_TOKEN` or generates a random token, registers it in Rocket state, and adds the token header to allowed CORS headers in `crates/api/src/lib.rs`.
- Protect all plugin/marketplace mutation handlers (add/remove/update install/uninstall/update/prune/validate/open/config write, etc.) by requiring `ApiToken` on those routes in `crates/api/src/routes/plugins.rs`.
- Desktop changes: generate a per-session token in the Tauri command that starts the embedded API, pass `auth_token` to `start(ApiOptions)`, return the token to the frontend, and include the token on every API request from the desktop client via `X-AGHUB-API-TOKEN` (changes in `crates/desktop/src-tauri/src/commands/server.rs`, `crates/desktop/src-tauri/src/lib.rs`, `crates/desktop/src/providers/server.tsx`, `crates/desktop/src/hooks/use-api.ts`, `crates/desktop/src/lib/api.ts`, and `crates/desktop/src/requests/client.ts`).
- Add a unit test that verifies preflight includes the token header and a test that `POST /api/v1/plugins/marketplaces` without the token returns `401 Unauthorized`, and adjust small diagnostics (`ApiError`/ErrorBody derive debug) in `crates/api/src/error.rs`.

### Testing

- `cargo fmt --check` and `git diff --check` both succeeded locally.
- Frontend formatting checks using `cd crates/desktop && bun run prettier --check ...` succeeded for the modified files.
- Added Rocket unit test that asserts `POST /api/v1/plugins/marketplaces` without the token is rejected; the test is included but running the full `cargo test -p aghub-api` in this environment was blocked by crates.io download failures (`CONNECT tunnel failed, response 403`).
- Desktop TypeScript `bun run typecheck` could not be completed because `node_modules` are not available in the container; full frontend typechecking is therefore pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbb983ac48329b2be1bf1090ec0ac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented API token-based authentication system to enhance security for all API endpoints.
  * Desktop application now automatically generates and manages authentication tokens on server startup, eliminating manual configuration.
  * All plugin operations including enable, disable, install, uninstall, update, configuration, and marketplace management now require valid authentication verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->