### PR TITLE
fix(cc-plugins): validate GitHub marketplace manifests

### DIFF
--- a/crates/cc-plugins/src/installer/marketplace/source.rs
+++ b/crates/cc-plugins/src/installer/marketplace/source.rs
@@ -291,6 +291,9 @@ pub(in crate::installer::marketplace) fn github_owner_repo(
 		.unwrap_or(normalized);
 	aghub_git::resolve_remote_source(&clean)
 		.ok()
+		.filter(|resolved| {
+			resolved.source_type == aghub_git::RemoteSourceType::Github
+		})
 		.and_then(|resolved| {
 			resolved
 				.source
@@ -314,5 +317,36 @@ fn marketplace_plugin_repository(plugin: &MarketplacePlugin) -> Option<String> {
 			.and_then(|url| parse_github_tree_url(url).map(|(repo, _)| repo))
 			.or_else(|| plugin.homepage.clone()),
 		MarketplaceSource::Npm { .. } => plugin.homepage.clone(),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::github_owner_repo;
+
+	#[test]
+	fn github_owner_repo_accepts_github_sources() {
+		assert_eq!(
+			github_owner_repo(
+				"https://github.com/trusted/plugin/tree/main/example",
+			),
+			Some(("trusted".to_string(), "plugin".to_string()))
+		);
+		assert_eq!(
+			github_owner_repo("git@github.com:trusted/plugin.git"),
+			Some(("trusted".to_string(), "plugin".to_string()))
+		);
+	}
+
+	#[test]
+	fn github_owner_repo_rejects_non_github_sources() {
+		assert_eq!(
+			github_owner_repo("https://evil.example/trusted/plugin"),
+			None
+		);
+		assert_eq!(
+			github_owner_repo("https://gitlab.com/trusted/plugin"),
+			None
+		);
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent manifest/source confusion where a non-GitHub marketplace URL could be interpreted as a GitHub owner/repo and cause the app to trust a manifest from raw.githubusercontent.com while installing content from the original (potentially attacker-controlled) URL.

### Description
- Require `aghub_git::resolve_remote_source(&clean)` to be classified as `RemoteSourceType::Github` before extracting `owner/repo` in `crates/cc-plugins/src/installer/marketplace/source.rs::github_owner_repo`.
- Add unit tests that confirm GitHub inputs are accepted and non-GitHub hosts (e.g. `evil.example`, `gitlab.com`) are rejected by `github_owner_repo`.

### Testing
- Ran `cargo fmt --package aghub-cc-plugins -- --check` which succeeded.
- Ran `git diff --check` which succeeded.
- Attempted `cargo test -p aghub-cc-plugins github_owner_repo` but execution was blocked by environment network/toolchain issues (crates.io downloads failed), so the added unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc068147883299362859eed4896c6)