### PR TITLE
ci: pin sccache action to immutable SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
                   tool: just
 
             - name: Setup sccache
-              uses: mozilla-actions/sccache-action@v0.0.10
+              uses: mozilla-actions/sccache-action@3ca012d1e0c8c9f363fd709c2a022f9d0c3d6f85
 
             - name: Rust Cache
               uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
                   targets: ${{ matrix.target }}
 
             - name: Setup sccache
-              uses: mozilla-actions/sccache-action@v0.0.10
+              uses: mozilla-actions/sccache-action@3ca012d1e0c8c9f363fd709c2a022f9d0c3d6f85
 
             - name: Rust Cache
               uses: Swatinem/rust-cache@v2
@@ -192,7 +192,7 @@ jobs:
                   targets: ${{ matrix.target }}
 
             - name: Setup sccache
-              uses: mozilla-actions/sccache-action@v0.0.10
+              uses: mozilla-actions/sccache-action@3ca012d1e0c8c9f363fd709c2a022f9d0c3d6f85
 
             - name: Rust Cache
               uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
### Motivation
- Mitigate CI/CD supply-chain risk by removing mutable third-party action tags that run in CI and privileged release jobs before signing and upload steps.

### Description
- Replace `mozilla-actions/sccache-action@v0.0.10` with the immutable commit `mozilla-actions/sccache-action@3ca012d1e0c8c9f363fd709c2a022f9d0c3d6f85` in `.github/workflows/ci.yml` and `.github/workflows/release.yml`.
- The change pins the sccache action used by the check job and both release build jobs so upstream tag retargeting cannot alter the action code executed during sensitive build steps.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and it passed.
- Executed a Python validator that scans workflow files for `mozilla-actions/sccache-action@` refs and enforces a 40-character SHA pin, which confirmed all occurrences are pinned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc7806a488329be3711d428c5afac)