### PR TITLE
fix(desktop): harden deep link MCP import review

### DIFF
--- a/crates/desktop/src/components/deep-link-import-modal.tsx
+++ b/crates/desktop/src/components/deep-link-import-modal.tsx
@@ -39,6 +39,38 @@ function transportLabel(transport: TransportDto): string {
 	return transport.type.toUpperCase();
 }
 
+function hasMapEntries(value: Record<string, string> | null): boolean {
+	return Boolean(value && Object.keys(value).length > 0);
+}
+
+function formatReviewValue(value: unknown): string {
+	if (Array.isArray(value)) {
+		return value.length > 0 ? JSON.stringify(value, null, 2) : "[]";
+	}
+
+	if (value && typeof value === "object") {
+		return JSON.stringify(value, null, 2);
+	}
+
+	return String(value);
+}
+
+interface TransportReviewFieldProps {
+	label: string;
+	value: string;
+}
+
+function TransportReviewField({ label, value }: TransportReviewFieldProps) {
+	return (
+		<div className="space-y-1">
+			<p className="text-muted">{label}</p>
+			<pre className="max-h-28 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-surface-secondary px-3 py-2 font-mono text-xs text-foreground">
+				{value}
+			</pre>
+		</div>
+	);
+}
+
 export function DeepLinkImportModal({
 	intent,
 	onComplete,
@@ -61,6 +93,7 @@ export function DeepLinkImportModal({
 	const [selectedAgents, setSelectedAgents] = useState<Set<string>>(
 		() => new Set(),
 	);
+	const [hasExecutableConsent, setHasExecutableConsent] = useState(false);
 
 	const compatibleAgents = useMemo(() => {
 		if (!intent) {
@@ -190,6 +223,7 @@ export function DeepLinkImportModal({
 			return;
 		}
 		setSelectedAgents(new Set());
+		setHasExecutableConsent(false);
 		installMutation.reset();
 		resetInstallTarget();
 		onComplete();
@@ -200,6 +234,7 @@ export function DeepLinkImportModal({
 			handleClose();
 		} else if (isOpen && intent) {
 			setSelectedAgents(defaultSelectedAgents);
+			setHasExecutableConsent(false);
 			resetInstallTarget();
 		}
 	};
@@ -208,6 +243,9 @@ export function DeepLinkImportModal({
 		installMutation.data ?? installMutation.context?.pendingResults ?? [];
 	const isInstalling = installMutation.isPending;
 	const error = installMutation.error?.message ?? null;
+	const requiresExecutableConsent =
+		intent?.kind === "mcp-config-install" &&
+		intent.transport.type === "stdio";
 
 	return (
 		<Modal.Backdrop
@@ -253,38 +291,143 @@ export function DeepLinkImportModal({
 						)}
 
 						{intent?.kind === "mcp-config-install" && (
-							<Card>
-								<Card.Header>
-									<div>
-										<p className="text-sm text-muted">
-											{t("mcp")}
-										</p>
-										<h3 className="text-base font-semibold">
-											{intent.name}
-										</h3>
-									</div>
-								</Card.Header>
-								<Card.Content className="space-y-2 text-sm">
-									<div className="flex items-center justify-between gap-3">
-										<span className="text-muted">
-											{t("type")}
-										</span>
-										<span>
-											{transportLabel(intent.transport)}
-										</span>
-									</div>
-									<div className="space-y-1">
-										<p className="text-muted">
-											{t("details")}
-										</p>
-										<p className="break-all rounded-lg bg-surface-secondary px-3 py-2 text-foreground">
-											{formatTransportSummary(
-												intent.transport,
+							<div className="space-y-3">
+								{requiresExecutableConsent && (
+									<Alert status="warning">
+										<Alert.Indicator />
+										<Alert.Content>
+											<Alert.Title>
+												{t("executableMcpWarningTitle")}
+											</Alert.Title>
+											<Alert.Description>
+												{t(
+													"executableMcpWarningDescription",
+												)}
+											</Alert.Description>
+										</Alert.Content>
+									</Alert>
+								)}
+								<Card>
+									<Card.Header>
+										<div>
+											<p className="text-sm text-muted">
+												{t("mcp")}
+											</p>
+											<h3 className="break-all text-base font-semibold">
+												{intent.name}
+											</h3>
+										</div>
+									</Card.Header>
+									<Card.Content className="space-y-3 text-sm">
+										<div className="flex items-center justify-between gap-3">
+											<span className="text-muted">
+												{t("type")}
+											</span>
+											<span>
+												{transportLabel(
+													intent.transport,
+												)}
+											</span>
+										</div>
+										<div className="space-y-1">
+											<p className="text-muted">
+												{t("details")}
+											</p>
+											<p className="break-all rounded-lg bg-surface-secondary px-3 py-2 text-foreground">
+												{formatTransportSummary(
+													intent.transport,
+												)}
+											</p>
+										</div>
+										<div className="space-y-2">
+											{intent.transport.type ===
+											"stdio" ? (
+												<>
+													<TransportReviewField
+														label={t("command")}
+														value={
+															intent.transport
+																.command
+														}
+													/>
+													<TransportReviewField
+														label={t("args")}
+														value={formatReviewValue(
+															intent.transport
+																.args,
+														)}
+													/>
+													<TransportReviewField
+														label={t("env")}
+														value={
+															hasMapEntries(
+																intent.transport
+																	.env,
+															)
+																? formatReviewValue(
+																		intent
+																			.transport
+																			.env,
+																	)
+																: t("noEnvVars")
+														}
+													/>
+												</>
+											) : (
+												<>
+													<TransportReviewField
+														label={t("url")}
+														value={
+															intent.transport.url
+														}
+													/>
+													<TransportReviewField
+														label={t("headers")}
+														value={
+															hasMapEntries(
+																intent.transport
+																	.headers,
+															)
+																? formatReviewValue(
+																		intent
+																			.transport
+																			.headers,
+																	)
+																: t("noHeaders")
+														}
+													/>
+												</>
 											)}
-										</p>
-									</div>
-								</Card.Content>
-							</Card>
+											{intent.timeout !== undefined && (
+												<TransportReviewField
+													label={t("timeout")}
+													value={t("timeoutSeconds", {
+														seconds: intent.timeout,
+													})}
+												/>
+											)}
+										</div>
+									</Card.Content>
+								</Card>
+								{requiresExecutableConsent &&
+									results.length === 0 && (
+										<label className="flex gap-3 rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm">
+											<input
+												type="checkbox"
+												checked={hasExecutableConsent}
+												onChange={(event) =>
+													setHasExecutableConsent(
+														event.currentTarget
+															.checked,
+													)
+												}
+											/>
+											<span>
+												{t("confirmExecutableMcp")}
+											</span>
+										</label>
+									)}
+							</div>
 						)}
 
 						{results.length === 0 && (
@@ -350,6 +493,8 @@ export function DeepLinkImportModal({
 									isDisabled={
 										selectedAgents.size === 0 ||
 										isInstalling ||
+										(requiresExecutableConsent &&
+											!hasExecutableConsent) ||
 										(installToProject && !selectedProject)
 									}
 								>

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -726,6 +726,11 @@ export default {
 	deepLinkUnsupportedType: "This deep link type is not supported.",
 	deepLinkInvalidSkill: "This skill link is missing required fields.",
 	deepLinkInvalidMcp: "This MCP link payload is invalid.",
+	executableMcpWarningTitle: "This MCP can run a command",
+	executableMcpWarningDescription:
+		"Stdio MCP servers are executable commands that agents may run later. Only install this import if you trust its source and have reviewed every command, argument, and environment variable below.",
+	confirmExecutableMcp:
+		"I understand this import can persist an executable command for agents to run later.",
 	copyTooltip: "Copy as JSON",
 	copied: "Copied to clipboard",
 	editTooltip: "Edit server",

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -723,6 +723,11 @@ export default {
 	deepLinkUnsupportedType: "该深链类型暂不支持。",
 	deepLinkInvalidSkill: "该技能链接缺少必要字段。",
 	deepLinkInvalidMcp: "该 MCP 链接载荷无效。",
+	executableMcpWarningTitle: "此 MCP 可以运行命令",
+	executableMcpWarningDescription:
+		"Stdio MCP 服务器是代理稍后可能运行的可执行命令。仅当你信任来源，并已查看下方的所有命令、参数和环境变量后才安装。",
+	confirmExecutableMcp:
+		"我了解此导入会持久保存一个可执行命令，供代理稍后运行。",
 
 	// skills.sh
 	searchMarketSkills: "在 skills.sh 搜索技能...",

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -721,6 +721,11 @@ export default {
 	deepLinkUnsupportedType: "此深層連結類型目前不支援。",
 	deepLinkInvalidSkill: "此技能連結缺少必要欄位。",
 	deepLinkInvalidMcp: "此 MCP 連結載荷無效。",
+	executableMcpWarningTitle: "此 MCP 可以執行命令",
+	executableMcpWarningDescription:
+		"Stdio MCP 伺服器是代理稍後可能執行的可執行命令。只有在你信任來源，並已檢視下方所有命令、參數和環境變數後才安裝。",
+	confirmExecutableMcp:
+		"我了解此匯入會持久保存一個可執行命令，供代理稍後執行。",
 
 	// skills.sh
 	searchMarketSkills: "在 skills.sh 搜尋技能...",


### PR DESCRIPTION
### Motivation
- Deep-link MCP imports could persist attacker-controlled executable `stdio` commands and hidden env/headers with only a terse summary shown to users, creating a high-risk vector for later command execution by agents. 
- The UI needed to expose all persisted transport fields and require explicit user acknowledgement before installing imports that will create executable MCP entries.

### Description
- Add explicit transport review UI by introducing `TransportReviewField`, `formatReviewValue`, and `hasMapEntries` to render command, args, env, URL, headers, and timeout values in the deep-link import modal. 
- Add a prominent warning alert and a required consent checkbox for `stdio`-type MCP imports that disables the `Install` button until the user confirms understanding. 
- Reset and manage the consent state when the modal opens/closes so consent cannot be silently carried across intents. 
- Add localized strings for the warning and consent (`executableMcpWarningTitle`, `executableMcpWarningDescription`, `confirmExecutableMcp`) in English, Simplified Chinese, and Traditional Chinese (`crates/desktop/src/lib/locales/{en,zh-Hans,zh-Hant}.ts`).

### Testing
- Ran formatting check with `bunx prettier --check crates/desktop/src/components/deep-link-import-modal.tsx crates/desktop/src/lib/locales/en.ts crates/desktop/src/lib/locales/zh-Hans.ts crates/desktop/src/lib/locales/zh-Hant.ts`, which succeeded. 
- Ran `git diff --check`, which reported no whitespace/patch errors. 
- Attempted TypeScript typecheck with `bun run --cwd crates/desktop typecheck`, but it was blocked because dependencies could not be installed in the environment (`bun install` failed with npm registry 403s), so full `tsc` verification could not be completed. 
- Changes were committed to the branch (`fix(desktop): harden deep link MCP import review`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fcaa21cc48329b0f843f386404390)