### PR TITLE
fix(api): restrict GitHub credentials to github.com scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "ts-rs",
+ "url",
  "uuid",
  "which",
 ]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -41,3 +41,4 @@ keyring = { version = "3", features = [
 uuid = { version = "1", features = [ "v4" ] }
 log = "0.4.30"
 reqwest = { version = "0.13", features = [ "json" ] }
+url = { workspace = true }

--- a/crates/api/src/routes/skills.rs
+++ b/crates/api/src/routes/skills.rs
@@ -1120,6 +1120,27 @@ pub fn get_project_skill_lock(
 	}))
 }
 
+fn require_github_credential_url(url: &str) -> Result<(), ApiError> {
+	let parsed = url::Url::parse(url).map_err(|_| {
+		ApiError::new(
+			Status::BadRequest,
+			"GitHub credentials can only be used with github.com HTTPS URLs",
+			"INVALID_GITHUB_CREDENTIAL_URL",
+		)
+	})?;
+
+	let host = parsed.host_str().unwrap_or_default();
+	if parsed.scheme() == "https" && host.eq_ignore_ascii_case("github.com") {
+		return Ok(());
+	}
+
+	Err(ApiError::new(
+		Status::BadRequest,
+		"GitHub credentials can only be used with github.com HTTPS URLs",
+		"INVALID_GITHUB_CREDENTIAL_URL",
+	))
+}
+
 #[post("/skills/git/scan", data = "<body>")]
 pub async fn git_scan_skills(
 	body: Json<GitScanRequest>,
@@ -1163,6 +1184,10 @@ pub async fn git_scan_skills(
 		} else {
 			None
 		};
+
+	if credential_token.is_some() {
+		require_github_credential_url(&req.url)?;
+	}
 
 	let url = req.url.clone();
 	let branch = req.branch.clone();
@@ -1518,6 +1543,44 @@ mod tests {
 	fn env_lock() -> &'static Mutex<()> {
 		static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 		LOCK.get_or_init(|| Mutex::new(()))
+	}
+
+	#[test]
+	fn github_credential_url_accepts_github_https() {
+		assert!(require_github_credential_url(
+			"https://github.com/owner/repo.git",
+		)
+		.is_ok());
+	}
+
+	#[test]
+	fn github_credential_url_rejects_non_github_hosts() {
+		let err = require_github_credential_url(
+			"https://attacker.example/owner/repo.git",
+		)
+		.unwrap_err();
+
+		assert_eq!(err.status, Status::BadRequest);
+		assert_eq!(err.body.code, "INVALID_GITHUB_CREDENTIAL_URL");
+	}
+
+	#[test]
+	fn github_credential_url_rejects_github_lookalikes() {
+		let err = require_github_credential_url(
+			"https://github.com.attacker.example/owner/repo.git",
+		)
+		.unwrap_err();
+
+		assert_eq!(err.status, Status::BadRequest);
+	}
+
+	#[test]
+	fn github_credential_url_rejects_non_https_github() {
+		let err =
+			require_github_credential_url("http://github.com/owner/repo.git")
+				.unwrap_err();
+
+		assert_eq!(err.status, Status::BadRequest);
 	}
 
 	#[test]


### PR DESCRIPTION
### Motivation

- Prevent stored GitHub PATs from being attached to arbitrary HTTPS git remotes during the skill import flow to block credential-relay/exfiltration.

### Description

- Add `require_github_credential_url` in `crates/api/src/routes/skills.rs` that validates a scan URL is HTTPS and the host equals `github.com` before a stored credential token is used. 
- Enforce the guard in the `POST /skills/git/scan` handler so credentials are only injected for validated GitHub URLs. 
- Add unit tests for the validator covering accepted GitHub HTTPS URLs, non-GitHub hosts, GitHub lookalike hosts, and non-HTTPS GitHub URLs in `crates/api/src/routes/skills.rs`. 
- Add a direct `url` dependency to `crates/api/Cargo.toml` and update `Cargo.lock` to enable URL parsing in the new validation code.

### Testing

- Ran `cargo fmt --package aghub-api -- --check`, which succeeded. 
- Attempted `cargo test -p aghub-api github_credential_url` but execution was blocked by the environment (missing `sccache` wrapper binary) so unit tests could not be executed there. 
- Attempted `RUSTC_WRAPPER= cargo test -p aghub-api github_credential_url` but dependency downloads failed due to network tunnel errors (`CONNECT tunnel failed, response 403`), so tests could not be run in the CI-like environment either. 
- The change is intentionally minimal and focused on host validation; further hardening (e.g., tightening CORS, requiring an origin/session token) remains recommended but out of scope for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd0d0a9488329a9ba1b6c233f47bd)