### PR TITLE
fix: validate Homebrew release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,17 @@ jobs:
         name: Update Homebrew Tap
         needs: [build-tauri, build-cli]
         runs-on: ubuntu-latest
+        env:
+            RELEASE_TAG: ${{ github.event.inputs.version || github.ref_name }}
         steps:
+            - name: Validate release tag
+              shell: bash
+              run: |
+                  if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+                      echo "Invalid release tag: $RELEASE_TAG" >&2
+                      exit 1
+                  fi
+
             - name: Checkout Homebrew Tap
               uses: actions/checkout@v6
               with:
@@ -247,7 +257,7 @@ jobs:
 
             - name: Update Formula and Cask
               env:
-                  VERSION: ${{ github.event.inputs.version || github.ref_name }}
+                  VERSION: ${{ env.RELEASE_TAG }}
               run: |
                   VERSION="${VERSION#v}"
                   echo "Updating for version: ${VERSION}"
@@ -334,5 +344,5 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add aghub-cli.rb Casks/aghub.rb
-                  git commit -m "Update Homebrew formula and cask for aghub v${{ github.event.inputs.version || github.ref_name }}" || echo "No changes to commit"
+                  git commit -m "Update Homebrew formula and cask for aghub ${RELEASE_TAG}" || echo "No changes to commit"
                   git push


### PR DESCRIPTION
### Motivation
- Prevent command-injection via unvalidated `version`/release-tag interpolation in the Homebrew publishing job of `release.yml` which had access to the `HOMEBREW_TAP_TOKEN` after checkout.\
- Ensure the job uses a validated, self-contained value for the release tag when constructing files and commit messages.\

### Description
- Hardened `.github/workflows/release.yml` by introducing a `RELEASE_TAG` environment variable for the `publish-homebrew` job that sources `github.event.inputs.version || github.ref_name`.\
- Added a `Validate release tag` step that runs a strict regex validation (`^vMAJOR.MINOR.PATCH` with optional prerelease/build metadata) before the Homebrew tap is checked out.\
- Updated the `Update Formula and Cask` step to consume `VERSION: ${{ env.RELEASE_TAG }}` so downstream shell code uses the validated value.\
- Replaced the direct Actions-expression interpolation in the `git commit` message with the shell environment variable (`${RELEASE_TAG}`) to avoid pre-expanded quote-breaking expressions.\

### Testing
- Ran `git diff --check HEAD` to ensure no whitespace/patch issues and it passed.\
- Parsed the workflow YAML with Ruby: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'` and it parsed successfully.\
- Executed a bash validation harness exercising valid and invalid tag examples against the introduced regex (including attempted quote-breaking payloads) and the validation behaved as expected (accepted valid tags and rejected malicious/invalid strings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd1a2e99c832983e6a0cb6f1d4f98)