### PR TITLE
test(api): add route-level mutation coverage

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -264,7 +264,38 @@ mod tests {
 	use rocket::http::{ContentType, Header, Status};
 	use rocket::local::blocking::{Client, LocalResponse};
 	use serde_json::{json, Value};
+	use std::ffi::OsString;
 	use std::path::Path;
+	use std::sync::{Mutex, MutexGuard, OnceLock};
+
+	struct PathEnvGuard {
+		_lock: MutexGuard<'static, ()>,
+		previous: Option<OsString>,
+	}
+
+	impl Drop for PathEnvGuard {
+		fn drop(&mut self) {
+			match &self.previous {
+				Some(path) => std::env::set_var("PATH", path),
+				None => std::env::remove_var("PATH"),
+			}
+		}
+	}
+
+	fn env_lock() -> &'static Mutex<()> {
+		static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+		LOCK.get_or_init(|| Mutex::new(()))
+	}
+
+	fn hide_cli_path() -> PathEnvGuard {
+		let lock = env_lock().lock().expect("env lock");
+		let previous = std::env::var_os("PATH");
+		std::env::set_var("PATH", "");
+		PathEnvGuard {
+			_lock: lock,
+			previous,
+		}
+	}
 
 	fn test_client(app_data_dir: &Path) -> Client {
 		Client::tracked(build_rocket(
@@ -373,6 +404,7 @@ mod tests {
 
 	#[test]
 	fn route_skill_create_update_delete_persists_project_files() {
+		let _path_guard = hide_cli_path();
 		let app_data_dir = tempfile::tempdir().expect("app data dir");
 		let project_dir = tempfile::tempdir().expect("project dir");
 		let client = test_client(app_data_dir.path());
@@ -478,9 +510,15 @@ mod tests {
 		let body = response_json(response);
 		assert_eq!(body["transport"]["args"], json!(["updated.js"]));
 
+		let config_path = project_dir.path().join(".mcp.json");
+		assert!(config_path.exists(), "mcp config should be persisted");
+		let persisted =
+			std::fs::read_to_string(&config_path).expect("mcp config");
+		assert!(persisted.contains("route-mcp"));
+		assert!(persisted.contains("updated.js"));
+
 		let response = delete_json(&client, &item_uri);
 		assert_eq!(response.status(), Status::NoContent);
-		let config_path = project_dir.path().join(".mcp.json");
 		if config_path.exists() {
 			let persisted =
 				std::fs::read_to_string(config_path).expect("mcp config");

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -261,16 +261,77 @@ pub async fn start(options: ApiOptions) -> Result<(), rocket::Error> {
 #[cfg(test)]
 mod tests {
 	use super::{build_rocket, default_app_data_dir};
-	use rocket::http::{Header, Status};
-	use rocket::local::blocking::Client;
+	use rocket::http::{ContentType, Header, Status};
+	use rocket::local::blocking::{Client, LocalResponse};
+	use serde_json::{json, Value};
+	use std::path::Path;
+
+	fn test_client(app_data_dir: &Path) -> Client {
+		Client::tracked(build_rocket(
+			rocket::Config::default(),
+			app_data_dir.to_path_buf(),
+		))
+		.expect("client")
+	}
+
+	fn project_query(project_root: &Path) -> String {
+		let mut serializer =
+			url::form_urlencoded::Serializer::new(String::new());
+		serializer.append_pair("scope", "project");
+		serializer.append_pair("project_root", &project_root.to_string_lossy());
+		serializer.finish()
+	}
+
+	fn response_json(response: LocalResponse<'_>) -> Value {
+		let body = response.into_string().expect("response body");
+		serde_json::from_str(&body).expect("json response")
+	}
+
+	fn assert_json_error(
+		response: LocalResponse<'_>,
+		status: Status,
+		code: &str,
+	) {
+		assert_eq!(response.status(), status);
+		let body = response_json(response);
+		assert_eq!(body["code"], code);
+	}
+
+	fn post_json<'c>(
+		client: &'c Client,
+		uri: &'c str,
+		body: Value,
+	) -> LocalResponse<'c> {
+		client
+			.post(uri)
+			.header(ContentType::JSON)
+			.body(body.to_string())
+			.dispatch()
+	}
+
+	fn put_json<'c>(
+		client: &'c Client,
+		uri: &'c str,
+		body: Value,
+	) -> LocalResponse<'c> {
+		client
+			.put(uri)
+			.header(ContentType::JSON)
+			.body(body.to_string())
+			.dispatch()
+	}
+
+	fn get_json<'c>(client: &'c Client, uri: &'c str) -> LocalResponse<'c> {
+		client.get(uri).dispatch()
+	}
+
+	fn delete_json<'c>(client: &'c Client, uri: &'c str) -> LocalResponse<'c> {
+		client.delete(uri).dispatch()
+	}
 
 	#[test]
 	fn plugin_install_rejects_remote_browser_origin() {
-		let client = Client::tracked(build_rocket(
-			rocket::Config::default(),
-			default_app_data_dir(),
-		))
-		.expect("client");
+		let client = test_client(&default_app_data_dir());
 
 		let response = client
 			.post("/api/v1/plugins/install")
@@ -286,11 +347,7 @@ mod tests {
 
 	#[test]
 	fn plugin_preflight_routes_return_cors_response() {
-		let client = Client::tracked(build_rocket(
-			rocket::Config::default(),
-			default_app_data_dir(),
-		))
-		.expect("client");
+		let client = test_client(&default_app_data_dir());
 
 		let path = "/api/v1/plugins/uninstall";
 		let response = client
@@ -312,5 +369,202 @@ mod tests {
 			response.headers().get_one("Access-Control-Allow-Headers"),
 			Some("content-type"),
 		);
+	}
+
+	#[test]
+	fn route_skill_create_update_delete_persists_project_files() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let project_dir = tempfile::tempdir().expect("project dir");
+		let client = test_client(app_data_dir.path());
+		let query = project_query(project_dir.path());
+		let collection_uri = format!("/api/v1/agents/claude/skills?{query}");
+		let item_uri =
+			format!("/api/v1/agents/claude/skills/route-skill?{query}");
+
+		let response = post_json(
+			&client,
+			&collection_uri,
+			json!({
+				"name": "route-skill",
+				"description": "created",
+				"author": null,
+				"version": null,
+				"content": "# Body",
+				"tools": [],
+			}),
+		);
+		assert_eq!(response.status(), Status::Created);
+		let body = response_json(response);
+		assert_eq!(body["name"], "route-skill");
+
+		let response = get_json(&client, &item_uri);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body["description"], "created");
+
+		let response = put_json(
+			&client,
+			&item_uri,
+			json!({
+				"description": "updated",
+				"content": "# Updated",
+			}),
+		);
+		assert_eq!(response.status(), Status::Ok);
+
+		let skill_file = project_dir
+			.path()
+			.join(".claude/skills/route-skill/SKILL.md");
+		let persisted =
+			std::fs::read_to_string(&skill_file).expect("persisted skill");
+		assert!(persisted.contains("route-skill"));
+		assert!(persisted.contains("updated"));
+		assert!(persisted.contains("# Updated"));
+
+		let response = delete_json(&client, &item_uri);
+		assert_eq!(response.status(), Status::NoContent);
+		assert!(!skill_file.exists(), "deleted skill file should be removed");
+
+		let response = get_json(&client, &collection_uri);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body.as_array().expect("skill list").len(), 0);
+	}
+
+	#[test]
+	fn route_mcp_create_update_delete_persists_project_config() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let project_dir = tempfile::tempdir().expect("project dir");
+		let client = test_client(app_data_dir.path());
+		let query = project_query(project_dir.path());
+		let collection_uri = format!("/api/v1/agents/claude/mcps?{query}");
+		let item_uri = format!("/api/v1/agents/claude/mcps/route-mcp?{query}");
+
+		let response = post_json(
+			&client,
+			&collection_uri,
+			json!({
+				"name": "route-mcp",
+				"transport": {
+					"type": "stdio",
+					"command": "node",
+					"args": ["server.js"],
+				},
+				"timeout": null,
+			}),
+		);
+		assert_eq!(response.status(), Status::Created);
+		let body = response_json(response);
+		assert_eq!(body["name"], "route-mcp");
+		assert_eq!(body["transport"]["command"], "node");
+
+		let response = get_json(&client, &item_uri);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body["transport"]["args"], json!(["server.js"]));
+
+		let response = put_json(
+			&client,
+			&item_uri,
+			json!({
+				"transport": {
+					"type": "stdio",
+					"command": "node",
+					"args": ["updated.js"],
+				},
+			}),
+		);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body["transport"]["args"], json!(["updated.js"]));
+
+		let response = delete_json(&client, &item_uri);
+		assert_eq!(response.status(), Status::NoContent);
+		let config_path = project_dir.path().join(".mcp.json");
+		if config_path.exists() {
+			let persisted =
+				std::fs::read_to_string(config_path).expect("mcp config");
+			assert!(!persisted.contains("route-mcp"));
+		}
+	}
+
+	#[test]
+	fn route_sub_agent_create_update_delete_persists_project_file() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let project_dir = tempfile::tempdir().expect("project dir");
+		let client = test_client(app_data_dir.path());
+		let query = project_query(project_dir.path());
+		let collection_uri =
+			format!("/api/v1/agents/claude/sub-agents?{query}");
+		let item_uri =
+			format!("/api/v1/agents/claude/sub-agents/route-agent?{query}");
+
+		let response = post_json(
+			&client,
+			&collection_uri,
+			json!({
+				"name": "route-agent",
+				"description": "created",
+				"instruction": "Create useful output.",
+			}),
+		);
+		assert_eq!(response.status(), Status::Created);
+		let body = response_json(response);
+		assert_eq!(body["name"], "route-agent");
+
+		let response = get_json(&client, &item_uri);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body["description"], "created");
+
+		let response = put_json(
+			&client,
+			&item_uri,
+			json!({
+				"description": "updated",
+				"instruction": "Use updated instructions.",
+			}),
+		);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body["instruction"], "Use updated instructions.");
+
+		let sub_agent_file =
+			project_dir.path().join(".claude/agents/route-agent.md");
+		let persisted = std::fs::read_to_string(&sub_agent_file)
+			.expect("persisted sub-agent");
+		assert!(persisted.contains("updated"));
+		assert!(persisted.contains("Use updated instructions."));
+
+		let response = delete_json(&client, &item_uri);
+		assert_eq!(response.status(), Status::NoContent);
+		assert!(
+			!sub_agent_file.exists(),
+			"deleted sub-agent file should be removed"
+		);
+
+		let response = get_json(&client, &collection_uri);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body.as_array().expect("sub-agent list").len(), 0);
+	}
+
+	#[test]
+	fn route_invalid_scope_returns_bad_request_json() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let client = test_client(app_data_dir.path());
+		let response = client
+			.get("/api/v1/agents/claude/skills?scope=sideways")
+			.dispatch();
+
+		assert_json_error(response, Status::BadRequest, "INVALID_PARAM");
+		let response = client
+			.get("/api/v1/agents/claude/skills?scope=sideways")
+			.dispatch();
+		let body = response_json(response);
+		let error = body["error"].as_str().expect("error message");
+		assert!(error.contains("global"));
+		assert!(error.contains("project"));
+		assert!(error.contains("all"));
 	}
 }

--- a/crates/desktop/src/pages/inference-providers/claude-panel.tsx
+++ b/crates/desktop/src/pages/inference-providers/claude-panel.tsx
@@ -337,6 +337,12 @@ function ClaudeCreateProviderDialog({
 		modelOptions,
 	);
 
+	const handleClose = () => {
+		setSelectedProviderId("");
+		setModelSelection({});
+		onClose();
+	};
+
 	const createMutation = useMutation({
 		...createClaudeProviderMutationOptions({
 			api,
@@ -358,12 +364,6 @@ function ClaudeCreateProviderDialog({
 
 	const isPending = createMutation.isPending;
 	const hasAnthropicProviders = anthropicProviders.length > 0;
-
-	const handleClose = () => {
-		setSelectedProviderId("");
-		setModelSelection({});
-		onClose();
-	};
 
 	const handleModelChange = (
 		route: ClaudeModelRoute,

--- a/crates/desktop/src/pages/inference-providers/codex-panel.tsx
+++ b/crates/desktop/src/pages/inference-providers/codex-panel.tsx
@@ -139,6 +139,12 @@ function CodexCreateProviderDialog({
 	);
 	const effectiveModel = selectCodexModel(selectedModel, modelOptions);
 
+	const handleClose = () => {
+		setSelectedProviderId("");
+		setSelectedModel("");
+		onClose();
+	};
+
 	const createMutation = useMutation({
 		...createCodexProviderMutationOptions({
 			api,
@@ -153,12 +159,6 @@ function CodexCreateProviderDialog({
 	const activeError = createMutation.error;
 	const isPending = createMutation.isPending;
 	const hasResponseProviders = responseProviders.length > 0;
-
-	const handleClose = () => {
-		setSelectedProviderId("");
-		setSelectedModel("");
-		onClose();
-	};
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();


### PR DESCRIPTION
# Plan 001: Add route-level API mutation tests

> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving to the next step. If anything in the STOP conditions section occurs, stop and report — do not improvise. When done, update the status row for this plan in `plans/README.md` unless a reviewer told you they maintain the index.
>
> **Drift check (run first)**: `git diff --stat b014ccbd..HEAD -- crates/api/src/lib.rs crates/api/src/routes/skills.rs crates/api/src/routes/mcps.rs crates/api/src/routes/sub_agents.rs crates/api/src/dto/skill.rs crates/api/src/dto/mcp.rs crates/api/src/dto/sub_agent.rs crates/api/src/extractors.rs`
> If any in-scope file changed since this plan was written, compare the Current state excerpts against the live code before proceeding; on mismatch, treat it as a STOP condition.

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: LOW
- **Depends on**: none
- **Category**: tests
- **Planned at**: commit `b014ccbd`, 2026-06-13

## Why this matters

The API exposes the highest-risk mutation surface in the project: skills, MCPs, sub-agents, inference providers, plugins, and credentials. Today most route code is exercised only through handler unit tests or lower-level core tests. Before hardening authentication and path handling, add Rocket local-client tests that prove DTO extraction, query parsing, status codes, catchers, and persisted file side effects work through real HTTP routes.

## Current state

Relevant files:

- `crates/api/src/lib.rs` — builds and mounts the Rocket app; currently contains only one Rocket local-client CORS preflight test.
- `crates/api/src/routes/skills.rs` — skill create/update/delete/import routes and helper unit tests.
- `crates/api/src/routes/mcps.rs` — MCP routes and a direct handler test for one unsupported-agent path.
- `crates/api/src/routes/sub_agents.rs` — sub-agent CRUD routes with no route-level tests.
- `crates/api/src/extractors.rs` — scope query parsing, including invalid-scope error behavior.

Current excerpts to verify before editing:

```rust
// crates/api/src/lib.rs:92
fn build_rocket(
	config: rocket::Config,
	app_data_dir: PathBuf,
) -> rocket::Rocket<rocket::Build> {
```

```rust
// crates/api/src/lib.rs:265
use rocket::local::blocking::Client;

#[test]
fn plugin_preflight_routes_return_cors_response() {
	let client = Client::tracked(build_rocket(
		rocket::Config::default(),
		default_app_data_dir(),
	))
	.expect("client");
```

```rust
// crates/api/src/routes/skills.rs:640
#[post("/agents/<agent>/skills?<scope..>", data = "<body>")]
pub async fn create_skill(
```

```rust
// crates/api/src/routes/mcps.rs:274
fn test_create_mcp_rejects_pi_agent() {
	let result = create_mcp(
```

```rust
// crates/api/src/extractors.rs:37
impl ScopeParams {
	pub fn resolve(&self) -> Result<ResolvedScope, ApiError> {
		let scope = self.scope.as_deref().unwrap_or("global");
```

Repo conventions:

- Rust uses hard tabs and 80-column formatting; run `cargo fmt` rather than hand-aligning with spaces.
- API tests already use Rocket's blocking `Client` and JSON DTOs.
- Use temp directories for filesystem side effects. Do not write to the real home directory or developer config paths.

## Commands you will need

| Purpose | Command | Expected on success |
| ------- | ------- | ------------------- |
| Narrow API tests | `cargo test -p aghub-api route_` | exit 0; the new route tests pass |
| Full API tests | `cargo test -p aghub-api` | exit 0; all API tests pass |
| Format check | `cargo fmt --all -- --check` | exit 0 |

## Scope

**In scope**:

- `crates/api/src/lib.rs` — preferred place for Rocket local-client integration tests because it can call private `build_rocket`.
- `crates/api/src/routes/skills.rs`, `crates/api/src/routes/mcps.rs`, `crates/api/src/routes/sub_agents.rs` — only if a tiny test-only helper must live next to route code.

**Out of scope**:

- Production route behavior.
- Authentication/CORS changes; those belong to plan 002.
- Skill path containment changes; those belong to plan 003.
- Desktop UI tests; those are a separate audit finding.

## Git workflow

- Branch: `advisor/001-api-mutation-tests`.
- Commit message: `test(api): add route-level mutation coverage`.
- Do not push or open a PR unless instructed.

## Steps

### Step 1: Add test helpers in `crates/api/src/lib.rs`

Inside the existing `#[cfg(test)] mod tests`, add helpers:

- `fn test_client(app_data_dir: &Path) -> Client` that calls `Client::tracked(build_rocket(rocket::Config::default(), app_data_dir.to_path_buf()))`.
- `fn project_query(project_root: &Path) -> String` that URL-encodes or safely formats `scope=project&project_root=<path>` for test URIs.
- `fn assert_json_error(response, status, code)` for invalid-scope/error tests.

Use `tempfile::tempdir()` for both `app_data_dir` and project roots.

**Verify**: `cargo test -p aghub-api plugin_preflight_routes_return_cors_response` → exit 0.

### Step 2: Add skill route mutation coverage

Add a test named `route_skill_create_update_delete_persists_project_files` that:

1. Creates `tempdir()/project` and sends `POST /api/v1/agents/claude/skills?scope=project&project_root=<project>` with JSON:
   `{"name":"route-skill","description":"created","author":null,"version":null,"content":"# Body","tools":[]}`.
2. Asserts HTTP 201 and response body has `name == "route-skill"`.
3. Sends `GET /api/v1/agents/claude/skills/route-skill?scope=project&project_root=<project>` and asserts HTTP 200 and `description == "created"`.
4. Sends `PUT` to the same route with JSON that changes `description` to `"updated"` and `content` to `"# Updated"`; assert HTTP 200.
5. Reads the persisted `SKILL.md` under the Claude project skill directory and asserts it contains `route-skill`, `updated`, and `# Updated`.
6. Sends `DELETE` to the same route and asserts HTTP 204; then assert the skill directory/file is gone or the skill no longer appears in `GET /skills`.

If the exact Claude project skill path differs, derive it through the manager/adapter rather than hard-coding a real user path.

**Verify**: `cargo test -p aghub-api route_skill_create_update_delete_persists_project_files -- --exact` → exit 0.

### Step 3: Add MCP route mutation coverage

Add a test named `route_mcp_create_update_delete_persists_project_config` that:

1. Uses a temp project root.
2. Sends `POST /api/v1/agents/claude/mcps?scope=project&project_root=<project>` with a stdio transport JSON body.
3. Asserts HTTP 201 and response transport command matches the request.
4. Sends `GET` for the MCP and asserts HTTP 200.
5. Sends `PUT` to rename or change args; assert HTTP 200.
6. Sends `DELETE`; assert HTTP 204.
7. Reads the project MCP config path, if present, to assert the server was removed after delete.

Use the existing route DTO shapes from `crates/api/src/dto/mcp.rs`; do not bypass HTTP by calling handlers directly.

**Verify**: `cargo test -p aghub-api route_mcp_create_update_delete_persists_project_config -- --exact` → exit 0.

### Step 4: Add sub-agent route mutation coverage

Add a test named `route_sub_agent_create_update_delete_persists_project_file` that:

1. Uses a temp project root.
2. Sends `POST /api/v1/agents/claude/sub-agents?scope=project&project_root=<project>` with JSON containing `name`, `description`, and `instruction`.
3. Asserts HTTP 201, then `GET` returns the created sub-agent.
4. Sends `PUT` with a new description/instruction; assert HTTP 200.
5. Sends `DELETE`; assert HTTP 204 and the sub-agent no longer appears in list.

If Claude project sub-agents are unsupported in the current descriptor, switch to the first registered agent that supports project sub-agents, but keep the test project-scoped and document the choice in a comment.

**Verify**: `cargo test -p aghub-api route_sub_agent_create_update_delete_persists_project_file -- --exact` → exit 0.

### Step 5: Add invalid-scope coverage

Add a test named `route_invalid_scope_returns_bad_request_json` that sends a real route request such as:

`GET /api/v1/agents/claude/skills?scope=sideways`

Assert:

- HTTP 400.
- JSON error code is `INVALID_PARAM`.
- Error text mentions accepted scopes: `global`, `project`, or `all`.

**Verify**: `cargo test -p aghub-api route_invalid_scope_returns_bad_request_json -- --exact` → exit 0.

## Test plan

New tests in `crates/api/src/lib.rs`:

- `route_skill_create_update_delete_persists_project_files`.
- `route_mcp_create_update_delete_persists_project_config`.
- `route_sub_agent_create_update_delete_persists_project_file`.
- `route_invalid_scope_returns_bad_request_json`.

Use `plugin_preflight_routes_return_cors_response` as the structural pattern for creating a Rocket client.

## Done criteria

- [ ] `cargo test -p aghub-api route_` exits 0 and runs the new tests.
- [ ] `cargo test -p aghub-api` exits 0.
- [ ] `cargo fmt --all -- --check` exits 0.
- [ ] New tests use temp dirs and do not write to real user config paths.
- [ ] No production behavior is changed.
- [ ] `plans/README.md` row 001 is updated to DONE by the executor.

## STOP conditions

Stop and report back if:

- The route signatures or DTO shapes no longer match the excerpts above.
- A test can only pass by writing to the real home directory.
- Creating project-scoped resources is impossible for every registered agent without production changes.
- Any verification command fails twice after reasonable test fixes.

## Maintenance notes

These tests are the safety net for plans 002 and 003. Reviewers should verify that they exercise actual Rocket requests rather than direct handler calls, and that they assert both response status/body and persisted filesystem side effects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup with shared HTTP/JSON helpers and a reusable test client.
  * Expanded integration coverage for create/update/delete persistence of skills, MCP project configuration, and sub-agent markdown files (including proper cleanup on delete).
  * Added a validation test ensuring invalid `scope` query parameters return `400 BadRequest` with a JSON error describing supported scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->