### PR TITLE
fix(api): require token for local API requests

### DIFF
--- a/crates/api/src/auth.rs
+++ b/crates/api/src/auth.rs
@@ -1,0 +1,49 @@
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome};
+use rocket::Request;
+
+pub const AUTHORIZATION_HEADER: &str = "Authorization";
+pub const TOKEN_HEADER: &str = "X-AGHUB-API-Token";
+
+pub struct ApiAuthState {
+	pub token: String,
+}
+
+pub struct ApiAuth;
+
+pub fn generate_auth_token() -> String {
+	uuid::Uuid::new_v4().simple().to_string()
+}
+
+fn bearer_token(value: &str) -> Option<&str> {
+	value.strip_prefix("Bearer ")
+}
+
+fn request_token(request: &Request<'_>) -> Option<String> {
+	request
+		.headers()
+		.get_one(AUTHORIZATION_HEADER)
+		.and_then(bearer_token)
+		.or_else(|| request.headers().get_one(TOKEN_HEADER))
+		.map(ToOwned::to_owned)
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ApiAuth {
+	type Error = ();
+
+	async fn from_request(
+		request: &'r Request<'_>,
+	) -> Outcome<Self, Self::Error> {
+		let Some(state) = request.rocket().state::<ApiAuthState>() else {
+			return Outcome::Error((Status::InternalServerError, ()));
+		};
+		let Some(token) = request_token(request) else {
+			return Outcome::Error((Status::Unauthorized, ()));
+		};
+		if token != state.token {
+			return Outcome::Error((Status::Forbidden, ()));
+		}
+		Outcome::Success(ApiAuth)
+	}
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -9,6 +9,7 @@ use rocket::{
 	Data, Request, Response,
 };
 
+pub mod auth;
 pub mod dto;
 pub mod editor_detection;
 pub mod error;
@@ -22,6 +23,9 @@ pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 pub struct ApiOptions {
 	pub port: u16,
 	pub app_data_dir: Option<PathBuf>,
+	pub auth_token: Option<String>,
+	pub allowed_origins: Vec<String>,
+	pub allowed_origin_regexes: Vec<String>,
 }
 
 impl ApiOptions {
@@ -29,6 +33,35 @@ impl ApiOptions {
 		Self {
 			port,
 			app_data_dir: None,
+			auth_token: None,
+			allowed_origins: default_allowed_origins(),
+			allowed_origin_regexes: default_allowed_origin_regexes(),
+		}
+	}
+
+	fn resolve(self) -> ResolvedApiOptions {
+		let env_token = std::env::var("AGHUB_API_TOKEN")
+			.ok()
+			.filter(|value| !value.trim().is_empty());
+		let configured_token = self
+			.auth_token
+			.filter(|value| !value.trim().is_empty())
+			.or(env_token);
+		let (auth_token, token_was_generated) =
+			if let Some(token) = configured_token {
+				(token, false)
+			} else {
+				(crate::auth::generate_auth_token(), true)
+			};
+		ResolvedApiOptions {
+			port: self.port,
+			app_data_dir: self
+				.app_data_dir
+				.unwrap_or_else(default_app_data_dir),
+			auth_token,
+			token_was_generated,
+			allowed_origins: self.allowed_origins,
+			allowed_origin_regexes: self.allowed_origin_regexes,
 		}
 	}
 }
@@ -37,6 +70,27 @@ fn default_app_data_dir() -> PathBuf {
 	dirs::data_dir()
 		.unwrap_or_else(std::env::temp_dir)
 		.join("aghub")
+}
+
+fn default_allowed_origins() -> Vec<String> {
+	vec![
+		"http://localhost:1420".to_string(),
+		"http://tauri.localhost".to_string(),
+		"https://tauri.localhost".to_string(),
+	]
+}
+
+fn default_allowed_origin_regexes() -> Vec<String> {
+	vec![r"^tauri://localhost$".to_string()]
+}
+
+struct ResolvedApiOptions {
+	port: u16,
+	app_data_dir: PathBuf,
+	auth_token: String,
+	token_was_generated: bool,
+	allowed_origins: Vec<String>,
+	allowed_origin_regexes: Vec<String>,
 }
 
 struct ApiLogFairing;
@@ -91,10 +145,14 @@ impl Fairing for ApiLogFairing {
 
 fn build_rocket(
 	config: rocket::Config,
-	app_data_dir: PathBuf,
+	options: ResolvedApiOptions,
 ) -> rocket::Rocket<rocket::Build> {
+	let allowed_origins = rocket_cors::AllowedOrigins::some(
+		&options.allowed_origins,
+		&options.allowed_origin_regexes,
+	);
 	let cors = rocket_cors::CorsOptions {
-		allowed_origins: rocket_cors::AllOrSome::All,
+		allowed_origins,
 		allowed_methods: vec![
 			rocket::http::Method::Get,
 			rocket::http::Method::Post,
@@ -107,10 +165,11 @@ fn build_rocket(
 		.collect(),
 		allowed_headers: rocket_cors::AllowedHeaders::some(&[
 			"Authorization",
+			"X-AGHUB-API-Token",
 			"Accept",
 			"Content-Type",
 		]),
-		allow_credentials: true,
+		allow_credentials: false,
 		..Default::default()
 	}
 	.to_cors()
@@ -121,7 +180,12 @@ fn build_rocket(
 		.manage(crate::state::GitCloneSessions {
 			sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
 		})
-		.manage(crate::state::InferenceProviderState { app_data_dir })
+		.manage(crate::state::InferenceProviderState {
+			app_data_dir: options.app_data_dir,
+		})
+		.manage(crate::auth::ApiAuthState {
+			token: options.auth_token,
+		})
 		.mount(
 			"/api/v1",
 			routes![
@@ -227,6 +291,8 @@ fn build_rocket(
 		.register(
 			"/",
 			catchers![
+				routes::catchers::unauthorized,
+				routes::catchers::forbidden,
 				routes::catchers::not_found,
 				routes::catchers::unprocessable_entity,
 				routes::catchers::internal_error,
@@ -236,16 +302,18 @@ fn build_rocket(
 }
 
 pub async fn start(options: ApiOptions) -> Result<(), rocket::Error> {
-	info!("starting aghub API server on 127.0.0.1:{}", options.port);
-	let app_data_dir =
-		options.app_data_dir.unwrap_or_else(default_app_data_dir);
+	let resolved = options.resolve();
+	if resolved.token_was_generated {
+		eprintln!("AGHUB_API_TOKEN={}", resolved.auth_token);
+	}
+	info!("starting aghub API server on 127.0.0.1:{}", resolved.port);
 	let config = rocket::Config {
-		port: options.port,
+		port: resolved.port,
 		address: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
 		log_level: rocket::config::LogLevel::Normal,
 		..rocket::Config::default()
 	};
-	build_rocket(config, app_data_dir)
+	build_rocket(config, resolved)
 		.launch()
 		.await
 		.inspect(|_rocket| {
@@ -260,7 +328,7 @@ pub async fn start(options: ApiOptions) -> Result<(), rocket::Error> {
 
 #[cfg(test)]
 mod tests {
-	use super::{build_rocket, default_app_data_dir};
+	use super::{build_rocket, default_app_data_dir, ApiOptions};
 	use rocket::http::{ContentType, Header, Status};
 	use rocket::local::blocking::{Client, LocalResponse};
 	use serde_json::{json, Value};
@@ -297,12 +365,24 @@ mod tests {
 		}
 	}
 
+	const TEST_AUTH_TOKEN: &str = "test-auth-token";
+
 	fn test_client(app_data_dir: &Path) -> Client {
+		let mut options = ApiOptions::new(0);
+		options.app_data_dir = Some(app_data_dir.to_path_buf());
+		options.auth_token = Some(TEST_AUTH_TOKEN.to_string());
 		Client::tracked(build_rocket(
 			rocket::Config::default(),
-			app_data_dir.to_path_buf(),
+			options.resolve(),
 		))
 		.expect("client")
+	}
+
+	fn auth_header() -> Header<'static> {
+		Header::new(
+			crate::auth::AUTHORIZATION_HEADER,
+			format!("Bearer {TEST_AUTH_TOKEN}"),
+		)
 	}
 
 	fn project_query(project_root: &Path) -> String {
@@ -310,6 +390,13 @@ mod tests {
 			url::form_urlencoded::Serializer::new(String::new());
 		serializer.append_pair("scope", "project");
 		serializer.append_pair("project_root", &project_root.to_string_lossy());
+		serializer.finish()
+	}
+
+	fn skill_content_query(skill_file: &Path) -> String {
+		let mut serializer =
+			url::form_urlencoded::Serializer::new(String::new());
+		serializer.append_pair("path", &skill_file.to_string_lossy());
 		serializer.finish()
 	}
 
@@ -335,6 +422,7 @@ mod tests {
 	) -> LocalResponse<'c> {
 		client
 			.post(uri)
+			.header(auth_header())
 			.header(ContentType::JSON)
 			.body(body.to_string())
 			.dispatch()
@@ -347,17 +435,60 @@ mod tests {
 	) -> LocalResponse<'c> {
 		client
 			.put(uri)
+			.header(auth_header())
 			.header(ContentType::JSON)
 			.body(body.to_string())
 			.dispatch()
 	}
 
-	fn get_json<'c>(client: &'c Client, uri: &'c str) -> LocalResponse<'c> {
-		client.get(uri).dispatch()
+	fn get_auth<'c>(client: &'c Client, uri: &'c str) -> LocalResponse<'c> {
+		client.get(uri).header(auth_header()).dispatch()
 	}
 
-	fn delete_json<'c>(client: &'c Client, uri: &'c str) -> LocalResponse<'c> {
-		client.delete(uri).dispatch()
+	fn delete_auth<'c>(client: &'c Client, uri: &'c str) -> LocalResponse<'c> {
+		client.delete(uri).header(auth_header()).dispatch()
+	}
+
+	#[test]
+	fn auth_options_generate_distinct_tokens() {
+		let first = crate::auth::generate_auth_token();
+		let second = crate::auth::generate_auth_token();
+
+		assert_ne!(first, second);
+		assert!(first.len() >= 32);
+	}
+
+	#[test]
+	fn auth_missing_token_returns_unauthorized_json() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let client = test_client(app_data_dir.path());
+		let response = client.get("/api/v1/agents").dispatch();
+
+		assert_json_error(response, Status::Unauthorized, "UNAUTHORIZED");
+	}
+
+	#[test]
+	fn auth_wrong_token_returns_forbidden_json() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let client = test_client(app_data_dir.path());
+		let response = client
+			.get("/api/v1/agents")
+			.header(Header::new(
+				crate::auth::AUTHORIZATION_HEADER,
+				"Bearer wrong-token",
+			))
+			.dispatch();
+
+		assert_json_error(response, Status::Forbidden, "FORBIDDEN");
+	}
+
+	#[test]
+	fn auth_correct_token_allows_api_access() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let client = test_client(app_data_dir.path());
+		let response = get_auth(&client, "/api/v1/agents");
+
+		assert_eq!(response.status(), Status::Ok);
 	}
 
 	#[test]
@@ -366,6 +497,7 @@ mod tests {
 
 		let response = client
 			.post("/api/v1/plugins/install")
+			.header(auth_header())
 			.header(Header::new("Origin", "https://evil.example"))
 			.header(Header::new("Content-Type", "application/json"))
 			.body(
@@ -387,7 +519,7 @@ mod tests {
 			.header(Header::new("Access-Control-Request-Method", "POST"))
 			.header(Header::new(
 				"Access-Control-Request-Headers",
-				"content-type",
+				"authorization,content-type",
 			))
 			.dispatch();
 
@@ -396,9 +528,37 @@ mod tests {
 			response.headers().get_one("Access-Control-Allow-Origin"),
 			Some("http://localhost:1420"),
 		);
+		let allow_headers = response
+			.headers()
+			.get_one("Access-Control-Allow-Headers")
+			.expect("allow headers");
+		assert!(allow_headers.contains("authorization"));
+		assert!(allow_headers.contains("content-type"));
 		assert_eq!(
-			response.headers().get_one("Access-Control-Allow-Headers"),
-			Some("content-type"),
+			response
+				.headers()
+				.get_one("Access-Control-Allow-Credentials"),
+			None,
+		);
+	}
+
+	#[test]
+	fn cors_disallowed_origin_does_not_grant_access() {
+		let client = test_client(&default_app_data_dir());
+
+		let response = client
+			.req(rocket::http::Method::Options, "/api/v1/plugins/uninstall")
+			.header(Header::new("Origin", "https://example.com"))
+			.header(Header::new("Access-Control-Request-Method", "POST"))
+			.header(Header::new(
+				"Access-Control-Request-Headers",
+				"authorization,content-type",
+			))
+			.dispatch();
+
+		assert_eq!(
+			response.headers().get_one("Access-Control-Allow-Origin"),
+			None,
 		);
 	}
 
@@ -412,6 +572,20 @@ mod tests {
 		let collection_uri = format!("/api/v1/agents/claude/skills?{query}");
 		let item_uri =
 			format!("/api/v1/agents/claude/skills/route-skill?{query}");
+		let missing_auth = client
+			.post(&collection_uri)
+			.header(ContentType::JSON)
+			.body(
+				json!({
+					"name": "route-skill",
+					"description": "created",
+					"content": "# Body",
+					"tools": [],
+				})
+				.to_string(),
+			)
+			.dispatch();
+		assert_json_error(missing_auth, Status::Unauthorized, "UNAUTHORIZED");
 
 		let response = post_json(
 			&client,
@@ -429,7 +603,7 @@ mod tests {
 		let body = response_json(response);
 		assert_eq!(body["name"], "route-skill");
 
-		let response = get_json(&client, &item_uri);
+		let response = get_auth(&client, &item_uri);
 		assert_eq!(response.status(), Status::Ok);
 		let body = response_json(response);
 		assert_eq!(body["description"], "created");
@@ -453,14 +627,36 @@ mod tests {
 		assert!(persisted.contains("updated"));
 		assert!(persisted.contains("# Updated"));
 
-		let response = delete_json(&client, &item_uri);
+		let response = delete_auth(&client, &item_uri);
 		assert_eq!(response.status(), Status::NoContent);
 		assert!(!skill_file.exists(), "deleted skill file should be removed");
 
-		let response = get_json(&client, &collection_uri);
+		let response = get_auth(&client, &collection_uri);
 		assert_eq!(response.status(), Status::Ok);
 		let body = response_json(response);
 		assert_eq!(body.as_array().expect("skill list").len(), 0);
+	}
+
+	#[test]
+	fn route_skill_content_requires_auth() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let skill_dir = tempfile::tempdir().expect("skill dir");
+		let skill_file = skill_dir.path().join("SKILL.md");
+		std::fs::write(
+			&skill_file,
+			"---\nname: route-skill\ndescription: route skill\n---\n\n# Body\n",
+		)
+		.expect("skill file");
+
+		let client = test_client(app_data_dir.path());
+		let query = skill_content_query(&skill_file);
+		let uri = format!("/api/v1/skills/content?{query}");
+		let response = client.get(&uri).dispatch();
+		assert_json_error(response, Status::Unauthorized, "UNAUTHORIZED");
+
+		let response = get_auth(&client, &uri);
+		assert_eq!(response.status(), Status::Ok);
+		assert_eq!(response_json(response), json!("# Body"));
 	}
 
 	#[test]
@@ -490,7 +686,7 @@ mod tests {
 		assert_eq!(body["name"], "route-mcp");
 		assert_eq!(body["transport"]["command"], "node");
 
-		let response = get_json(&client, &item_uri);
+		let response = get_auth(&client, &item_uri);
 		assert_eq!(response.status(), Status::Ok);
 		let body = response_json(response);
 		assert_eq!(body["transport"]["args"], json!(["server.js"]));
@@ -517,7 +713,7 @@ mod tests {
 		assert!(persisted.contains("route-mcp"));
 		assert!(persisted.contains("updated.js"));
 
-		let response = delete_json(&client, &item_uri);
+		let response = delete_auth(&client, &item_uri);
 		assert_eq!(response.status(), Status::NoContent);
 		if config_path.exists() {
 			let persisted =
@@ -550,7 +746,7 @@ mod tests {
 		let body = response_json(response);
 		assert_eq!(body["name"], "route-agent");
 
-		let response = get_json(&client, &item_uri);
+		let response = get_auth(&client, &item_uri);
 		assert_eq!(response.status(), Status::Ok);
 		let body = response_json(response);
 		assert_eq!(body["description"], "created");
@@ -574,14 +770,14 @@ mod tests {
 		assert!(persisted.contains("updated"));
 		assert!(persisted.contains("Use updated instructions."));
 
-		let response = delete_json(&client, &item_uri);
+		let response = delete_auth(&client, &item_uri);
 		assert_eq!(response.status(), Status::NoContent);
 		assert!(
 			!sub_agent_file.exists(),
 			"deleted sub-agent file should be removed"
 		);
 
-		let response = get_json(&client, &collection_uri);
+		let response = get_auth(&client, &collection_uri);
 		assert_eq!(response.status(), Status::Ok);
 		let body = response_json(response);
 		assert_eq!(body.as_array().expect("sub-agent list").len(), 0);
@@ -593,11 +789,13 @@ mod tests {
 		let client = test_client(app_data_dir.path());
 		let response = client
 			.get("/api/v1/agents/claude/skills?scope=sideways")
+			.header(auth_header())
 			.dispatch();
 
 		assert_json_error(response, Status::BadRequest, "INVALID_PARAM");
 		let response = client
 			.get("/api/v1/agents/claude/skills?scope=sideways")
+			.header(auth_header())
 			.dispatch();
 		let body = response_json(response);
 		let error = body["error"].as_str().expect("error message");

--- a/crates/api/src/routes/agents.rs
+++ b/crates/api/src/routes/agents.rs
@@ -2,6 +2,7 @@ use aghub_core::{availability, registry};
 use rocket::serde::json::Json;
 use std::path::Path;
 
+use crate::auth::ApiAuth;
 use crate::dto::agents::{
 	AgentAvailabilityDto, AgentInfo, CapabilitiesDto, McpCapabilitiesDto,
 	ScopeSupportDto, SkillCapabilitiesDto, SkillsPathsDto,
@@ -22,7 +23,7 @@ fn format_path(path: std::path::PathBuf) -> String {
 }
 
 #[get("/agents")]
-pub fn list_agents() -> Json<Vec<AgentInfo>> {
+pub fn list_agents(_auth: ApiAuth) -> Json<Vec<AgentInfo>> {
 	let agents = registry::iter_all()
 		.map(|d| {
 			let project_root = Path::new("");
@@ -98,7 +99,7 @@ pub fn list_agents() -> Json<Vec<AgentInfo>> {
 }
 
 #[get("/agents/availability")]
-pub fn check_availability() -> Json<Vec<AgentAvailabilityDto>> {
+pub fn check_availability(_auth: ApiAuth) -> Json<Vec<AgentAvailabilityDto>> {
 	let availability_info = availability::check_all_agents_availability();
 
 	let dtos: Vec<AgentAvailabilityDto> = availability_info
@@ -120,7 +121,7 @@ mod tests {
 
 	#[test]
 	fn test_list_agents_includes_pi_without_mcp_capabilities() {
-		let agents = list_agents().into_inner();
+		let agents = list_agents(ApiAuth).into_inner();
 		let pi = agents
 			.into_iter()
 			.find(|agent| agent.id == "pi")

--- a/crates/api/src/routes/catchers.rs
+++ b/crates/api/src/routes/catchers.rs
@@ -3,6 +3,22 @@ use rocket::Request;
 
 use crate::error::ErrorBody;
 
+#[catch(401)]
+pub fn unauthorized(_: &Request) -> Json<ErrorBody> {
+	Json(ErrorBody {
+		error: "Authentication token is required".to_string(),
+		code: "UNAUTHORIZED",
+	})
+}
+
+#[catch(403)]
+pub fn forbidden(_: &Request) -> Json<ErrorBody> {
+	Json(ErrorBody {
+		error: "Authentication token is invalid".to_string(),
+		code: "FORBIDDEN",
+	})
+}
+
 #[catch(404)]
 pub fn not_found(req: &Request) -> Json<ErrorBody> {
 	Json(ErrorBody {

--- a/crates/api/src/routes/credentials.rs
+++ b/crates/api/src/routes/credentials.rs
@@ -3,6 +3,7 @@ use rocket::http::Status;
 use rocket::serde::json::Json;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::ApiAuth;
 use crate::dto::credential::{CreateCredentialRequest, CredentialResponse};
 use crate::error::{ApiCreated, ApiNoContent, ApiResult};
 
@@ -51,7 +52,7 @@ fn internal_err(msg: impl Into<String>) -> crate::error::ApiError {
 }
 
 #[get("/credentials")]
-pub fn list_credentials() -> ApiResult<Vec<CredentialResponse>> {
+pub fn list_credentials(_auth: ApiAuth) -> ApiResult<Vec<CredentialResponse>> {
 	let creds = load_credentials().map_err(internal_err)?;
 	debug!("loaded {} stored credentials", creds.len());
 	Ok(Json(
@@ -67,6 +68,7 @@ pub fn list_credentials() -> ApiResult<Vec<CredentialResponse>> {
 
 #[post("/credentials", data = "<body>")]
 pub fn create_credential(
+	_auth: ApiAuth,
 	body: Json<CreateCredentialRequest>,
 ) -> ApiCreated<CredentialResponse> {
 	let mut creds = load_credentials().map_err(internal_err)?;
@@ -88,7 +90,7 @@ pub fn create_credential(
 }
 
 #[delete("/credentials/<id>")]
-pub fn delete_credential(id: &str) -> ApiNoContent {
+pub fn delete_credential(_auth: ApiAuth, id: &str) -> ApiNoContent {
 	let mut creds = load_credentials().map_err(internal_err)?;
 	let original_len = creds.len();
 	creds.retain(|c| c.id != id);

--- a/crates/api/src/routes/inference.rs
+++ b/crates/api/src/routes/inference.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use crate::auth::ApiAuth;
 use crate::dto::inference::{
 	AgentProviderResponse, ClaudeProviderStateResponse,
 	CodexProviderStateResponse, CreateAgentProviderRequest,
@@ -195,6 +196,7 @@ fn codex_state_response(
 
 #[get("/inference/providers")]
 pub fn list_inference_providers(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 ) -> ApiResult<Vec<InferenceProviderResponse>> {
 	let providers = store(state)
@@ -309,6 +311,7 @@ async fn fetch_models_dev_presets() -> Result<
 
 #[get("/inference/presets")]
 pub async fn list_inference_provider_presets(
+	_auth: ApiAuth,
 ) -> Json<Vec<InferenceProviderPresetResponse>> {
 	match fetch_models_dev_presets().await {
 		Ok(presets) if !presets.is_empty() => Json(presets),
@@ -318,6 +321,7 @@ pub async fn list_inference_provider_presets(
 
 #[get("/inference/agents/opencode/providers")]
 pub fn list_opencode_providers(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 ) -> ApiResult<Vec<AgentProviderResponse>> {
 	let store = store(state);
@@ -337,6 +341,7 @@ pub fn list_opencode_providers(
 
 #[get("/inference/agents/codex/providers")]
 pub fn list_codex_providers(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 ) -> ApiResult<Vec<AgentProviderResponse>> {
 	let store = store(state);
@@ -356,6 +361,7 @@ pub fn list_codex_providers(
 
 #[get("/inference/agents/codex/state")]
 pub fn get_codex_state(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 ) -> ApiResult<CodexProviderStateResponse> {
 	let store = store(state);
@@ -365,6 +371,7 @@ pub fn get_codex_state(
 
 #[post("/inference/agents/opencode/providers", data = "<body>")]
 pub fn create_opencode_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	body: Json<CreateAgentProviderRequest>,
 ) -> ApiCreated<AgentProviderResponse> {
@@ -380,6 +387,7 @@ pub fn create_opencode_provider(
 
 #[post("/inference/agents/codex/providers", data = "<body>")]
 pub fn create_codex_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	body: Json<CreateAgentProviderRequest>,
 ) -> ApiCreated<AgentProviderResponse> {
@@ -443,6 +451,7 @@ pub fn create_codex_provider(
 
 #[put("/inference/agents/opencode/providers/<id>", data = "<body>")]
 pub fn update_opencode_provider(
+	_auth: ApiAuth,
 	id: &str,
 	body: Json<UpdateAgentProviderRequest>,
 ) -> ApiResult<AgentProviderResponse> {
@@ -456,6 +465,7 @@ pub fn update_opencode_provider(
 
 #[put("/inference/agents/codex/providers/<id>", data = "<body>")]
 pub fn update_codex_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	id: &str,
 	body: Json<UpdateAgentProviderRequest>,
@@ -476,6 +486,7 @@ pub fn update_codex_provider(
 
 #[put("/inference/agents/codex/profile", data = "<body>")]
 pub fn update_codex_active_profile(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	body: Json<UpdateCodexActiveProfileRequest>,
 ) -> ApiResult<CodexProviderStateResponse> {
@@ -492,6 +503,7 @@ pub fn update_codex_active_profile(
 	data = "<body>"
 )]
 pub fn update_codex_profile_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	profile_id: &str,
 	body: Json<UpdateCodexProfileProviderRequest>,
@@ -513,6 +525,7 @@ pub fn update_codex_profile_provider(
 
 #[post("/inference/agents/opencode/providers/<id>/sync")]
 pub fn sync_opencode_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	id: &str,
 ) -> ApiResult<AgentProviderResponse> {
@@ -558,6 +571,7 @@ pub fn sync_opencode_provider(
 
 #[post("/inference/agents/codex/providers/<id>/sync")]
 pub fn sync_codex_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	id: &str,
 ) -> ApiResult<AgentProviderResponse> {
@@ -604,7 +618,7 @@ pub fn sync_codex_provider(
 }
 
 #[delete("/inference/agents/opencode/providers/<id>")]
-pub fn delete_opencode_provider(id: &str) -> ApiNoContent {
+pub fn delete_opencode_provider(_auth: ApiAuth, id: &str) -> ApiNoContent {
 	opencode_adapter()?
 		.remove_provider(id)
 		.map_err(ApiError::from)?;
@@ -613,6 +627,7 @@ pub fn delete_opencode_provider(id: &str) -> ApiNoContent {
 
 #[delete("/inference/agents/codex/providers/<id>")]
 pub fn delete_codex_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	id: &str,
 ) -> ApiNoContent {
@@ -625,6 +640,7 @@ pub fn delete_codex_provider(
 
 #[get("/inference/providers/<latin_name>/password")]
 pub fn get_inference_provider_password(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	latin_name: &str,
 ) -> ApiResult<InferenceProviderPasswordResponse> {
@@ -652,6 +668,7 @@ pub fn get_inference_provider_password(
 
 #[post("/inference/providers", data = "<body>")]
 pub fn create_inference_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	body: Json<CreateInferenceProviderRequest>,
 ) -> ApiCreated<InferenceProviderResponse> {
@@ -663,6 +680,7 @@ pub fn create_inference_provider(
 
 #[put("/inference/providers/<latin_name>", data = "<body>")]
 pub fn update_inference_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	latin_name: &str,
 	body: Json<UpdateInferenceProviderRequest>,
@@ -770,6 +788,7 @@ fn remove_agent_provider_references(
 
 #[delete("/inference/providers/<latin_name>")]
 pub fn delete_inference_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	latin_name: &str,
 ) -> ApiNoContent {
@@ -845,6 +864,7 @@ fn claude_state_response(
 
 #[get("/inference/agents/claude/state")]
 pub fn get_claude_state(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 ) -> ApiResult<ClaudeProviderStateResponse> {
 	let store = store(state);
@@ -854,6 +874,7 @@ pub fn get_claude_state(
 
 #[post("/inference/agents/claude/providers", data = "<body>")]
 pub fn create_claude_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	body: Json<CreateAgentProviderRequest>,
 ) -> ApiCreated<AgentProviderResponse> {
@@ -892,6 +913,7 @@ pub fn create_claude_provider(
 
 #[put("/inference/agents/claude/providers/<id>", data = "<body>")]
 pub fn update_claude_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	id: &str,
 	body: Json<UpdateAgentProviderRequest>,
@@ -937,6 +959,7 @@ pub fn update_claude_provider(
 
 #[post("/inference/agents/claude/providers/<id>/sync")]
 pub fn sync_claude_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	id: &str,
 ) -> ApiResult<AgentProviderResponse> {
@@ -996,6 +1019,7 @@ pub fn sync_claude_provider(
 
 #[delete("/inference/agents/claude/providers/<id>")]
 pub fn delete_claude_provider(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 	id: &str,
 ) -> ApiNoContent {
@@ -1007,6 +1031,7 @@ pub fn delete_claude_provider(
 
 #[delete("/inference/agents/claude/state")]
 pub fn clear_claude_state(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 ) -> ApiNoContent {
 	let _store = store(state);
@@ -1017,6 +1042,7 @@ pub fn clear_claude_state(
 
 #[delete("/inference/agents/codex/state")]
 pub fn clear_codex_state(
+	_auth: ApiAuth,
 	state: &State<InferenceProviderState>,
 ) -> ApiNoContent {
 	let store = store(state);

--- a/crates/api/src/routes/integrations.rs
+++ b/crates/api/src/routes/integrations.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 use rocket::serde::json::Json;
 
+use crate::auth::ApiAuth;
 use crate::dto::integrations::{
 	CodeEditorType, OpenWithEditorRequest, ToolInfoDto, ToolPreferencesDto,
 };
@@ -23,7 +24,7 @@ fn resolve_editor_path(path: &str) -> std::path::PathBuf {
 }
 
 #[get("/integrations/code-editors")]
-pub fn list_code_editors() -> Json<Vec<ToolInfoDto>> {
+pub fn list_code_editors(_auth: ApiAuth) -> Json<Vec<ToolInfoDto>> {
 	let editors: Vec<ToolInfoDto> = CodeEditorType::all()
 		.iter()
 		.map(ToolInfoDto::from)
@@ -33,6 +34,7 @@ pub fn list_code_editors() -> Json<Vec<ToolInfoDto>> {
 
 #[post("/integrations/open-with-editor", format = "json", data = "<request>")]
 pub async fn open_with_editor(
+	_auth: ApiAuth,
 	request: Json<OpenWithEditorRequest>,
 ) -> Result<(), String> {
 	let req = request.into_inner();
@@ -52,7 +54,7 @@ pub async fn open_with_editor(
 }
 
 #[get("/integrations/preferences")]
-pub fn get_preferences() -> Json<ToolPreferencesDto> {
+pub fn get_preferences(_auth: ApiAuth) -> Json<ToolPreferencesDto> {
 	Json(ToolPreferencesDto::default())
 }
 

--- a/crates/api/src/routes/market.rs
+++ b/crates/api/src/routes/market.rs
@@ -2,6 +2,7 @@ use rocket::http::Status;
 use rocket::serde::json::Json;
 use skills_sh::{Client, SearchParams};
 
+use crate::auth::ApiAuth;
 use crate::dto::market::MarketSkill;
 use crate::error::ApiError;
 
@@ -9,6 +10,7 @@ use crate::error::ApiError;
 /// `source` defaults to "skills-sh", extensible for future providers
 #[get("/skills-market/search?<q>&<limit>&<source>")]
 pub async fn search_skill_market(
+	_auth: ApiAuth,
 	q: &str,
 	limit: Option<usize>,
 	source: Option<&str>,

--- a/crates/api/src/routes/mcps.rs
+++ b/crates/api/src/routes/mcps.rs
@@ -6,6 +6,7 @@ use rocket::response::status::NoContent;
 use rocket::serde::json::Json;
 
 use crate::{
+	auth::ApiAuth,
 	dto::mcp::{CreateMcpRequest, McpResponse, UpdateMcpRequest},
 	dto::transfer::{
 		OperationBatchResponse, ReconcileRequest, TransferRequest,
@@ -38,6 +39,7 @@ fn check_mcp_supported(
 
 #[get("/agents/<agent>/mcps?<scope..>")]
 pub fn list_mcps(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	scope: ScopeParams,
 ) -> ApiResult<Vec<McpResponse>> {
@@ -60,6 +62,7 @@ pub fn list_mcps(
 
 #[post("/mcps/transfer", data = "<body>")]
 pub fn transfer_mcp_route(
+	_auth: ApiAuth,
 	body: Json<TransferRequest>,
 ) -> ApiResult<OperationBatchResponse> {
 	let req = body.into_inner();
@@ -76,6 +79,7 @@ pub fn transfer_mcp_route(
 
 #[post("/mcps/reconcile", data = "<body>")]
 pub fn reconcile_mcp_route(
+	_auth: ApiAuth,
 	body: Json<ReconcileRequest>,
 ) -> ApiResult<OperationBatchResponse> {
 	let req = body.into_inner();
@@ -118,6 +122,7 @@ pub fn reconcile_mcp_route(
 
 #[post("/agents/<agent>/mcps?<scope..>", data = "<body>")]
 pub fn create_mcp(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	scope: ScopeParams,
 	body: Json<CreateMcpRequest>,
@@ -140,6 +145,7 @@ pub fn create_mcp(
 
 #[get("/agents/<agent>/mcps/<name>?<scope..>")]
 pub fn get_mcp(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -167,6 +173,7 @@ pub fn get_mcp(
 
 #[put("/agents/<agent>/mcps/<name>?<scope..>", data = "<body>")]
 pub fn update_mcp(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -192,6 +199,7 @@ pub fn update_mcp(
 
 #[delete("/agents/<agent>/mcps/<name>?<scope..>")]
 pub fn delete_mcp(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -214,6 +222,7 @@ pub fn delete_mcp(
 
 #[post("/agents/<agent>/mcps/<name>/enable?<scope..>")]
 pub fn enable_mcp(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -231,6 +240,7 @@ pub fn enable_mcp(
 
 #[post("/agents/<agent>/mcps/<name>/disable?<scope..>")]
 pub fn disable_mcp(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -247,7 +257,10 @@ pub fn disable_mcp(
 }
 
 #[get("/agents/all/mcps?<scope..>")]
-pub fn list_all_agents_mcps(scope: ScopeParams) -> ApiResult<Vec<McpResponse>> {
+pub fn list_all_agents_mcps(
+	_auth: ApiAuth,
+	scope: ScopeParams,
+) -> ApiResult<Vec<McpResponse>> {
 	let resolved = scope.resolve()?;
 	let (resource_scope, project_root) = resolved_to_resource_scope(&resolved);
 	let items = load_all_agents(resource_scope, project_root.as_deref())
@@ -273,6 +286,7 @@ mod tests {
 	#[test]
 	fn test_create_mcp_rejects_pi_agent() {
 		let result = create_mcp(
+			ApiAuth,
 			AgentParam(AgentType::Pi),
 			ScopeParams {
 				scope: Some("global".to_string()),

--- a/crates/api/src/routes/plugins.rs
+++ b/crates/api/src/routes/plugins.rs
@@ -1,3 +1,4 @@
+use crate::auth::ApiAuth;
 use crate::dto::plugin::{
 	CCMarketplaceAddRequest, CCMarketplaceEntryResponse,
 	CCMarketplaceListResponse, CCMarketplaceMutationResponse,
@@ -275,7 +276,7 @@ fn sorted_entries(
 // ── List / Enable / Disable ──────────────────────────────────────────────────
 
 #[get("/plugins")]
-pub async fn list_plugins() -> ApiResult<CCPluginListResponse> {
+pub async fn list_plugins(_auth: ApiAuth) -> ApiResult<CCPluginListResponse> {
 	let manager = load_plugin_manager().await?;
 	let installer = try_load_plugin_installer();
 	let mut plugins: Vec<CCPluginResponse> = manager
@@ -289,6 +290,7 @@ pub async fn list_plugins() -> ApiResult<CCPluginListResponse> {
 
 #[post("/plugins/enable?<plugin_id>&<scope>")]
 pub async fn enable_plugin(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	plugin_id: &str,
 	scope: Option<&str>,
@@ -312,6 +314,7 @@ pub async fn enable_plugin(
 
 #[post("/plugins/disable?<plugin_id>&<scope>")]
 pub async fn disable_plugin(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	plugin_id: &str,
 	scope: Option<&str>,
@@ -337,6 +340,7 @@ pub async fn disable_plugin(
 
 #[post("/plugins/install", data = "<body>")]
 pub async fn install_plugin(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCPluginInstallRequest>,
 ) -> ApiResult<CCPluginInstallResponse> {
@@ -376,6 +380,7 @@ pub async fn install_plugin(
 
 #[post("/plugins/uninstall", data = "<body>")]
 pub async fn uninstall_plugin(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCPluginUninstallRequest>,
 ) -> ApiResult<CCPluginUninstallResponse> {
@@ -404,6 +409,7 @@ pub async fn uninstall_plugin(
 
 #[post("/plugins/update", data = "<body>")]
 pub async fn update_plugin(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCPluginUpdateRequest>,
 ) -> ApiResult<CCPluginUpdateResponse> {
@@ -447,6 +453,7 @@ pub async fn update_plugin(
 
 #[get("/plugins/detail?<plugin_id>")]
 pub async fn get_plugin_detail(
+	_auth: ApiAuth,
 	plugin_id: &str,
 ) -> ApiResult<CCPluginDetailResponse> {
 	let id = parse_plugin_id(plugin_id)?;
@@ -564,6 +571,7 @@ pub async fn get_plugin_detail(
 
 #[get("/plugins/config?<plugin_id>")]
 pub async fn get_plugin_config(
+	_auth: ApiAuth,
 	plugin_id: String,
 ) -> ApiResult<CCPluginConfigResponse> {
 	let id = parse_plugin_id(&plugin_id)?;
@@ -586,6 +594,7 @@ pub async fn get_plugin_config(
 
 #[post("/plugins/config", data = "<body>")]
 pub async fn update_plugin_config(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCPluginUpdateConfigRequest>,
 ) -> ApiResult<CCPluginConfigResponse> {
@@ -624,6 +633,7 @@ pub async fn update_plugin_config(
 
 #[delete("/plugins/config?<plugin_id>")]
 pub async fn delete_plugin_config(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	plugin_id: String,
 ) -> ApiResult<CCPluginConfigResponse> {
@@ -651,6 +661,7 @@ pub async fn delete_plugin_config(
 
 #[post("/plugins/open-folder?<plugin_id>&<scope>")]
 pub async fn open_plugin_folder(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	plugin_id: &str,
 	scope: Option<&str>,
@@ -669,6 +680,7 @@ pub async fn open_plugin_folder(
 
 #[post("/plugins/open-skill-in-editor", data = "<body>")]
 pub async fn open_plugin_skill_in_editor(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCPluginOpenSkillInEditorRequest>,
 ) -> ApiNoContent {
@@ -746,7 +758,9 @@ fn resolve_plugin_skill_path(
 // ── Marketplace ──────────────────────────────────────────────────────────────
 
 #[get("/plugins-market")]
-pub async fn list_plugin_market() -> ApiResult<Vec<CCPluginMarketResponse>> {
+pub async fn list_plugin_market(
+	_auth: ApiAuth,
+) -> ApiResult<Vec<CCPluginMarketResponse>> {
 	use aghub_cc_plugins::discovery::{DiscoveryConfig, UnifiedPluginRegistry};
 
 	let registry =
@@ -835,7 +849,9 @@ fn load_claude_cli() -> Result<ClaudeCli, ApiError> {
 }
 
 #[get("/plugins/marketplaces")]
-pub async fn list_marketplaces() -> ApiResult<CCMarketplaceListResponse> {
+pub async fn list_marketplaces(
+	_auth: ApiAuth,
+) -> ApiResult<CCMarketplaceListResponse> {
 	let cli = load_claude_cli()?;
 	let entries = cli.marketplace_list().await.map_err(|e| {
 		error!("Failed to list marketplaces: {e}");
@@ -855,6 +871,7 @@ pub async fn list_marketplaces() -> ApiResult<CCMarketplaceListResponse> {
 
 #[post("/plugins/marketplaces", data = "<body>")]
 pub async fn add_marketplace(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCMarketplaceAddRequest>,
 ) -> ApiResult<CCMarketplaceMutationResponse> {
@@ -882,6 +899,7 @@ pub async fn add_marketplace(
 
 #[delete("/plugins/marketplaces/<name>")]
 pub async fn remove_marketplace(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	name: &str,
 ) -> ApiResult<CCMarketplaceMutationResponse> {
@@ -903,6 +921,7 @@ pub async fn remove_marketplace(
 
 #[post("/plugins/marketplaces/<name>/update")]
 pub async fn update_marketplace_one(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	name: &str,
 ) -> ApiResult<CCMarketplaceMutationResponse> {
@@ -941,6 +960,7 @@ pub async fn update_marketplace_one(
 
 #[post("/plugins-market/update")]
 pub async fn update_marketplace(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 ) -> ApiResult<serde_json::Value> {
 	let installer = load_plugin_installer()?;
@@ -975,6 +995,7 @@ pub async fn update_marketplace(
 
 #[post("/plugins/prune", data = "<body>")]
 pub async fn prune_plugins(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCPluginPruneRequest>,
 ) -> ApiResult<CCPluginPruneResponse> {
@@ -997,6 +1018,7 @@ pub async fn prune_plugins(
 
 #[post("/plugins/validate", data = "<body>")]
 pub async fn validate_plugin(
+	_auth: ApiAuth,
 	_origin: TrustedLocalOrigin,
 	body: Json<CCPluginValidateRequest>,
 ) -> ApiResult<CCPluginValidateResponse> {
@@ -1020,7 +1042,7 @@ pub async fn validate_plugin(
 // ── CLI status ───────────────────────────────────────────────────────────────
 
 #[get("/plugins/cli/status")]
-pub async fn cli_status() -> Json<CCPluginCliStatusResponse> {
+pub async fn cli_status(_auth: ApiAuth) -> Json<CCPluginCliStatusResponse> {
 	let cli = match ClaudeCli::new() {
 		Ok(cli) => cli,
 		Err(e) => {

--- a/crates/api/src/routes/skills.rs
+++ b/crates/api/src/routes/skills.rs
@@ -14,6 +14,7 @@ use std::{collections::HashMap, time::Duration};
 use tokio::time::timeout;
 
 use crate::{
+	auth::ApiAuth,
 	dto::integrations::{
 		CodeEditorType, EditSkillFolderRequest, OpenSkillFolderRequest,
 	},
@@ -111,6 +112,7 @@ where
 
 #[post("/skills/transfer", data = "<body>")]
 pub fn transfer_skill_route(
+	_auth: ApiAuth,
 	body: Json<TransferRequest>,
 ) -> ApiResult<OperationBatchResponse> {
 	let req = body.into_inner();
@@ -127,6 +129,7 @@ pub fn transfer_skill_route(
 
 #[post("/skills/reconcile", data = "<body>")]
 pub fn reconcile_skill_route(
+	_auth: ApiAuth,
 	body: Json<ReconcileRequest>,
 ) -> ApiResult<OperationBatchResponse> {
 	let req = body.into_inner();
@@ -170,6 +173,7 @@ pub fn reconcile_skill_route(
 
 #[delete("/skills/by-path", data = "<body>")]
 pub async fn delete_skill_by_path(
+	_auth: ApiAuth,
 	body: Json<DeleteSkillByPathRequest>,
 ) -> ApiResult<DeleteSkillByPathResponse> {
 	let req = body.into_inner();
@@ -617,6 +621,7 @@ fn check_skills_mutable(
 
 #[get("/agents/<agent>/skills?<scope..>")]
 pub fn list_skills(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	scope: ScopeParams,
 ) -> ApiResult<Vec<SkillResponse>> {
@@ -639,6 +644,7 @@ pub fn list_skills(
 
 #[post("/agents/<agent>/skills?<scope..>", data = "<body>")]
 pub async fn create_skill(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	scope: ScopeParams,
 	body: Json<CreateSkillRequest>,
@@ -661,6 +667,7 @@ pub async fn create_skill(
 
 #[post("/agents/<agent>/skills/import?<scope..>", data = "<body>")]
 pub fn import_skill(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	scope: ScopeParams,
 	body: Json<crate::dto::skill::ImportSkillRequest>,
@@ -696,6 +703,7 @@ pub fn import_skill(
 
 #[get("/agents/<agent>/skills/<name>?<scope..>")]
 pub fn get_skill(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -724,6 +732,7 @@ pub fn get_skill(
 
 #[put("/agents/<agent>/skills/<name>?<scope..>", data = "<body>")]
 pub async fn update_skill(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -752,6 +761,7 @@ pub async fn update_skill(
 
 #[delete("/agents/<agent>/skills/<name>?<scope..>")]
 pub async fn delete_skill(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -777,6 +787,7 @@ pub async fn delete_skill(
 
 #[post("/agents/<agent>/skills/<name>/enable?<scope..>")]
 pub async fn enable_skill(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -797,6 +808,7 @@ pub async fn enable_skill(
 
 #[post("/agents/<agent>/skills/<name>/disable?<scope..>")]
 pub async fn disable_skill(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: &str,
 	scope: ScopeParams,
@@ -861,6 +873,7 @@ fn is_plugin_managed_skill(
 
 #[get("/agents/all/skills?<params..>")]
 pub(crate) async fn list_all_agents_skills(
+	_auth: ApiAuth,
 	params: SkillListParams,
 ) -> ApiResult<Vec<SkillResponse>> {
 	let include_managed = params.include_managed();
@@ -889,6 +902,7 @@ pub(crate) async fn list_all_agents_skills(
 
 #[post("/skills/install", data = "<body>")]
 pub async fn install_skill(
+	_auth: ApiAuth,
 	body: Json<InstallSkillRequest>,
 ) -> ApiResult<InstallSkillResponse> {
 	let req = body.into_inner();
@@ -991,6 +1005,7 @@ pub async fn install_skill(
 
 #[post("/skills/open", format = "json", data = "<request>")]
 pub async fn open_skill_folder(
+	_auth: ApiAuth,
 	request: Json<OpenSkillFolderRequest>,
 ) -> Result<(), String> {
 	let req = request.into_inner();
@@ -1005,6 +1020,7 @@ pub async fn open_skill_folder(
 
 #[post("/skills/edit", format = "json", data = "<request>")]
 pub async fn edit_skill_folder(
+	_auth: ApiAuth,
 	request: Json<EditSkillFolderRequest>,
 ) -> Result<(), String> {
 	let req = request.into_inner();
@@ -1039,7 +1055,10 @@ pub async fn edit_skill_folder(
 }
 
 #[get("/skills/content?<query..>")]
-pub fn get_skill_content(query: SkillContentQuery) -> ApiResult<String> {
+pub fn get_skill_content(
+	_auth: ApiAuth,
+	query: SkillContentQuery,
+) -> ApiResult<String> {
 	let path = expand_tilde_path(&query.path);
 	let content = std::fs::read_to_string(&path).map_err(|e| {
 		ApiError::new(
@@ -1063,6 +1082,7 @@ pub fn get_skill_content(query: SkillContentQuery) -> ApiResult<String> {
 
 #[get("/skills/tree?<query..>")]
 pub fn get_skill_tree(
+	_auth: ApiAuth,
 	query: SkillTreeQuery,
 ) -> ApiResult<SkillTreeNodeResponse> {
 	let path = expand_tilde_path(&query.path);
@@ -1072,7 +1092,9 @@ pub fn get_skill_tree(
 }
 
 #[get("/skills/lock/global")]
-pub fn get_global_skill_lock() -> ApiResult<GlobalSkillLockResponse> {
+pub fn get_global_skill_lock(
+	_auth: ApiAuth,
+) -> ApiResult<GlobalSkillLockResponse> {
 	let lock = skill::lock::global::read_skill_lock();
 	let skills: Vec<SkillLockEntryResponse> = lock
 		.skills
@@ -1099,6 +1121,7 @@ pub fn get_global_skill_lock() -> ApiResult<GlobalSkillLockResponse> {
 
 #[get("/skills/lock/project?<query..>")]
 pub fn get_project_skill_lock(
+	_auth: ApiAuth,
 	query: ProjectLockQuery,
 ) -> ApiResult<ProjectSkillLockResponse> {
 	let cwd = query.project_path.as_deref().map(std::path::Path::new);
@@ -1143,6 +1166,7 @@ fn require_github_credential_url(url: &str) -> Result<(), ApiError> {
 
 #[post("/skills/git/scan", data = "<body>")]
 pub async fn git_scan_skills(
+	_auth: ApiAuth,
 	body: Json<GitScanRequest>,
 	sessions: &rocket::State<GitCloneSessions>,
 ) -> ApiResult<GitScanResponse> {
@@ -1350,6 +1374,7 @@ fn detect_current_branch(repo_path: &std::path::Path) -> Option<String> {
 
 #[post("/skills/git/install", data = "<body>")]
 pub async fn git_install_skills(
+	_auth: ApiAuth,
 	body: Json<GitInstallRequest>,
 	sessions: &rocket::State<GitCloneSessions>,
 ) -> ApiResult<GitInstallResponse> {
@@ -1465,6 +1490,7 @@ pub async fn git_install_skills(
 /// agent identifiers.
 #[post("/skills/git/sync", data = "<body>")]
 pub async fn git_sync_skill(
+	_auth: ApiAuth,
 	body: Json<GitSyncRequest>,
 	sessions: &rocket::State<GitCloneSessions>,
 ) -> ApiResult<GitSyncResponse> {

--- a/crates/api/src/routes/sub_agents.rs
+++ b/crates/api/src/routes/sub_agents.rs
@@ -6,6 +6,7 @@ use rocket::response::status::NoContent;
 use rocket::serde::json::Json;
 
 use crate::{
+	auth::ApiAuth,
 	dto::sub_agent::{
 		CreateSubAgentRequest, SubAgentResponse, UpdateSubAgentRequest,
 	},
@@ -40,6 +41,7 @@ fn check_sub_agent_supported(
 
 #[post("/sub-agents/transfer", data = "<body>")]
 pub fn transfer_sub_agent_route(
+	_auth: ApiAuth,
 	body: Json<TransferRequest>,
 ) -> ApiResult<OperationBatchResponse> {
 	let req = body.into_inner();
@@ -56,6 +58,7 @@ pub fn transfer_sub_agent_route(
 
 #[post("/sub-agents/reconcile", data = "<body>")]
 pub fn reconcile_sub_agent_route(
+	_auth: ApiAuth,
 	body: Json<ReconcileRequest>,
 ) -> ApiResult<OperationBatchResponse> {
 	let req = body.into_inner();
@@ -98,6 +101,7 @@ pub fn reconcile_sub_agent_route(
 
 #[get("/agents/<agent>/sub-agents?<scope..>")]
 pub fn list_sub_agents(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	scope: ScopeParams,
 ) -> ApiResult<Vec<SubAgentResponse>> {
@@ -124,6 +128,7 @@ pub fn list_sub_agents(
 
 #[get("/agents/all/sub-agents?<scope..>")]
 pub fn list_all_agents_sub_agents(
+	_auth: ApiAuth,
 	scope: ScopeParams,
 ) -> ApiResult<Vec<SubAgentResponse>> {
 	let resolved = scope.resolve()?;
@@ -143,6 +148,7 @@ pub fn list_all_agents_sub_agents(
 
 #[get("/agents/<agent>/sub-agents/<name>?<scope..>")]
 pub fn get_sub_agent(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: String,
 	scope: ScopeParams,
@@ -182,6 +188,7 @@ pub fn get_sub_agent(
 
 #[post("/agents/<agent>/sub-agents?<scope..>", data = "<body>")]
 pub fn create_sub_agent(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	scope: ScopeParams,
 	body: Json<CreateSubAgentRequest>,
@@ -201,6 +208,7 @@ pub fn create_sub_agent(
 
 #[put("/agents/<agent>/sub-agents/<name>?<scope..>", data = "<body>")]
 pub fn update_sub_agent(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: String,
 	scope: ScopeParams,
@@ -239,6 +247,7 @@ pub fn update_sub_agent(
 
 #[delete("/agents/<agent>/sub-agents/<name>?<scope..>")]
 pub fn delete_sub_agent(
+	_auth: ApiAuth,
 	agent: AgentParam,
 	name: String,
 	scope: ScopeParams,

--- a/crates/desktop/src-tauri/src/commands/server.rs
+++ b/crates/desktop/src-tauri/src/commands/server.rs
@@ -1,7 +1,15 @@
 use crate::AppState;
 use aghub_api::{start, ApiOptions};
 use log::{debug, error, info};
+use serde::Serialize;
 use tauri::Manager;
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerInfo {
+	pub port: u16,
+	pub token: String,
+}
 
 fn find_available_port() -> Result<u16, String> {
 	let listener = std::net::TcpListener::bind("127.0.0.1:0")
@@ -14,32 +22,34 @@ fn find_available_port() -> Result<u16, String> {
 pub async fn start_server(
 	state: tauri::State<'_, AppState>,
 	app: tauri::AppHandle,
-) -> Result<u16, String> {
+) -> Result<ServerInfo, String> {
 	let app_data_dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
-	let port = {
-		let mut guard = state.port.lock().unwrap();
-		if let Some(port) = *guard {
-			debug!("reusing embedded API server port {port}");
-			return Ok(port);
+	let server = {
+		let mut guard = state.server.lock().unwrap();
+		if let Some(server) = guard.as_ref() {
+			debug!("reusing embedded API server port {}", server.port);
+			return Ok(server.clone());
 		}
 
 		let port = find_available_port()?;
-		*guard = Some(port);
+		let token = aghub_api::auth::generate_auth_token();
+		let server = ServerInfo { port, token };
+		*guard = Some(server.clone());
 		debug!("stored embedded API server port {port} in application state");
-		port
+		server
 	};
 
+	let port = server.port;
+	let token = server.token.clone();
 	info!("received request to start embedded API server on port {port}");
 	tokio::spawn(async move {
 		info!("starting embedded API server on 127.0.0.1:{port}");
-		if let Err(error) = start(ApiOptions {
-			port,
-			app_data_dir: Some(app_data_dir),
-		})
-		.await
-		{
+		let mut options = ApiOptions::new(port);
+		options.app_data_dir = Some(app_data_dir);
+		options.auth_token = Some(token);
+		if let Err(error) = start(options).await {
 			error!("embedded API server exited with error: {error}");
 		}
 	});
-	Ok(port)
+	Ok(server)
 }

--- a/crates/desktop/src-tauri/src/lib.rs
+++ b/crates/desktop/src-tauri/src/lib.rs
@@ -17,7 +17,7 @@ mod commands;
 pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 pub struct AppState {
-	pub port: std::sync::Mutex<Option<u16>>,
+	pub server: std::sync::Mutex<Option<commands::server::ServerInfo>>,
 }
 
 fn default_log_config() -> commands::logging::LogConfig {
@@ -232,7 +232,7 @@ pub fn run() {
 				.build(),
 		)
 		.manage(AppState {
-			port: std::sync::Mutex::new(None),
+			server: std::sync::Mutex::new(None),
 		})
 		.plugin(tauri_plugin_deep_link::init())
 		.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {

--- a/crates/desktop/src/contexts/server.tsx
+++ b/crates/desktop/src/contexts/server.tsx
@@ -4,6 +4,7 @@ import { createContext, use } from "react";
 export interface ServerContextValue {
 	port: number;
 	baseUrl: string;
+	token: string;
 }
 
 export const ServerContext = createContext<ServerContextValue | null>(null);

--- a/crates/desktop/src/hooks/use-api.ts
+++ b/crates/desktop/src/hooks/use-api.ts
@@ -3,7 +3,7 @@ import { getApiClient } from "../requests/client";
 import { useServer } from "./use-server";
 
 export function useApi() {
-	const { baseUrl } = useServer();
+	const { baseUrl, token } = useServer();
 
-	return useMemo(() => getApiClient(baseUrl), [baseUrl]);
+	return useMemo(() => getApiClient(baseUrl, token), [baseUrl, token]);
 }

--- a/crates/desktop/src/lib/api.ts
+++ b/crates/desktop/src/lib/api.ts
@@ -72,9 +72,12 @@ interface ApiErrorBody {
 	code?: string;
 }
 
-export function createApi(baseUrl: string) {
+export function createApi(baseUrl: string, token: string) {
 	const client = ky.create({
 		prefix: baseUrl,
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
 		hooks: {
 			beforeError: [
 				async ({ error }) => {

--- a/crates/desktop/src/providers/server.tsx
+++ b/crates/desktop/src/providers/server.tsx
@@ -5,15 +5,20 @@ import { useEffect, useState } from "react";
 import type { ServerProviderProps } from "../contexts/server";
 import { ServerContext } from "../contexts/server";
 
+interface ServerInfo {
+	port: number;
+	token: string;
+}
+
 export function ServerProvider({ children }: ServerProviderProps) {
-	const [port, setPort] = useState<number | null>(null);
+	const [server, setServer] = useState<ServerInfo | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		invoke<number>("start_server")
+		invoke<ServerInfo>("start_server")
 			.then((value) => {
-				void info(`Desktop API server started on port ${value}`);
-				setPort(value);
+				void info(`Desktop API server started on port ${value.port}`);
+				setServer(value);
 			})
 			.catch((e) => {
 				console.error("Failed to start desktop API server:", e);
@@ -31,7 +36,7 @@ export function ServerProvider({ children }: ServerProviderProps) {
 		);
 	}
 
-	if (port === null) {
+	if (server === null) {
 		return (
 			<div className="flex h-screen items-center justify-center">
 				<Spinner size="lg" />
@@ -41,7 +46,11 @@ export function ServerProvider({ children }: ServerProviderProps) {
 
 	return (
 		<ServerContext
-			value={{ port, baseUrl: `http://localhost:${port}/api/v1` }}
+			value={{
+				port: server.port,
+				baseUrl: `http://localhost:${server.port}/api/v1`,
+				token: server.token,
+			}}
 		>
 			{children}
 		</ServerContext>

--- a/crates/desktop/src/requests/client.ts
+++ b/crates/desktop/src/requests/client.ts
@@ -4,14 +4,15 @@ export type ApiClient = ReturnType<typeof createApi>;
 
 const clients = new Map<string, ApiClient>();
 
-export function getApiClient(baseUrl: string): ApiClient {
-	const existing = clients.get(baseUrl);
+export function getApiClient(baseUrl: string, token: string): ApiClient {
+	const cacheKey = `${baseUrl}\0${token}`;
+	const existing = clients.get(cacheKey);
 
 	if (existing) {
 		return existing;
 	}
 
-	const client = createApi(baseUrl);
-	clients.set(baseUrl, client);
+	const client = createApi(baseUrl, token);
+	clients.set(cacheKey, client);
 	return client;
 }


### PR DESCRIPTION
# Plan 002: Gate the localhost API with a session token and strict CORS

> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving to the next step. If anything in the STOP conditions section occurs, stop and report — do not improvise. When done, update the status row for this plan in `plans/README.md` unless a reviewer told you they maintain the index.
>
> **Drift check (run first)**: `git diff --stat b014ccbd..HEAD -- crates/api/src/lib.rs crates/api/src/main.rs crates/api/src/routes crates/api/src/state.rs crates/desktop/src-tauri/src/commands/server.rs crates/desktop/src/providers/server.tsx crates/desktop/src/contexts/server.tsx crates/desktop/src/lib/api.ts crates/desktop/src/generated`
> If any in-scope file changed since this plan was written, compare the Current state excerpts against the live code before proceeding; on mismatch, treat it as a STOP condition.

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/001-add-api-mutation-tests.md`
- **Category**: security
- **Planned at**: commit `b014ccbd`, 2026-06-13

## Why this matters

The API is bound to localhost, but it accepts broad browser-origin traffic and has no request-authenticity check. It mounts credential and mutating config routes, including a route that returns a stored inference provider API key. A random desktop port lowers accidental exposure but does not authenticate requests; the standalone API uses a fixed port. This plan adds an unguessable per-process token, requires it on API routes, and narrows CORS so browser requests cannot freely use credentials from any origin.

## Current state

Relevant files:

- `crates/api/src/lib.rs` — defines `ApiOptions`, CORS, Rocket app mounting, and tests.
- `crates/api/src/main.rs` — starts standalone API on port 8000.
- `crates/desktop/src-tauri/src/commands/server.rs` — starts the embedded API and returns only a port.
- `crates/desktop/src/providers/server.tsx` and `crates/desktop/src/contexts/server.tsx` — store the API base URL for the React app.
- `crates/desktop/src/lib/api.ts` — creates the `ky` client used by all requests.

Current excerpts to verify before editing:

```rust
// crates/api/src/lib.rs:18
pub struct ApiOptions {
	pub port: u16,
	pub app_data_dir: Option<PathBuf>,
}
```

```rust
// crates/api/src/lib.rs:96
let cors = rocket_cors::CorsOptions {
	allowed_origins: rocket_cors::AllOrSome::All,
	allowed_methods: vec![
```

```rust
// crates/api/src/lib.rs:113
	allow_credentials: true,
	..Default::default()
}
```

```rust
// crates/api/src/routes/inference.rs:627
#[get("/inference/providers/<latin_name>/password")]
pub fn get_inference_provider_password(
```

```rust
// crates/api/src/routes/credentials.rs:68
#[post("/credentials", data = "<body>")]
pub fn create_credential(
```

```rust
// crates/desktop/src-tauri/src/commands/server.rs:10
#[tauri::command]
pub async fn start_server(
	state: tauri::State<'_, AppState>,
	app: tauri::AppHandle,
) -> Result<u16, String> {
```

```ts
// crates/desktop/src/lib/api.ts:75
export function createApi(baseUrl: string) {
	const client = ky.create({
		prefix: baseUrl,
```

Repo conventions:

- Rust routes use Rocket 0.5 attributes and return `ApiResult`/`ApiNoContent` aliases.
- Frontend uses strict TypeScript and Bun; generated DTOs live under `crates/desktop/src/generated`.
- Do not log or persist the generated API token except where explicitly needed to hand it to the desktop renderer in memory.

## Commands you will need

| Purpose | Command | Expected on success |
| ------- | ------- | ------------------- |
| API auth tests | `cargo test -p aghub-api auth` | exit 0; unauthorized/authorized/CORS tests pass |
| Full API tests | `cargo test -p aghub-api` | exit 0 |
| DTO generation, if route DTOs change | `cd crates/desktop && bun run generate:dto` | exit 0; generated files updated |
| Desktop typecheck | `cd crates/desktop && bun run typecheck` | exit 0 |
| Format check | `cargo fmt --all -- --check` | exit 0 |

## Scope

**In scope**:

- `crates/api/src/lib.rs`.
- `crates/api/src/main.rs`.
- A new API auth module if useful, e.g. `crates/api/src/auth.rs`.
- Route signatures under `crates/api/src/routes/` only to add an auth guard parameter.
- `crates/desktop/src-tauri/src/commands/server.rs`.
- `crates/desktop/src/providers/server.tsx`.
- `crates/desktop/src/contexts/server.tsx`.
- `crates/desktop/src/lib/api.ts`.
- Generated DTO files only if a new Tauri return type is exported through the existing generation flow.

**Out of scope**:

- Reworking endpoint response shapes beyond auth errors.
- Removing or changing the credential/password routes themselves.
- Tauri CSP/capability hardening; that is a separate finding.
- Path traversal fixes; those belong to plan 003.

## Git workflow

- Branch: `advisor/002-local-api-auth`.
- Commit message: `fix(api): require token for local API requests`.
- Do not push or open a PR unless instructed.

## Steps

### Step 1: Add API auth configuration and token generation

In `crates/api/src/lib.rs`:

1. Extend `ApiOptions` with:
   - `auth_token: Option<String>`.
   - `allowed_origins: Vec<String>` or a small origin config type.
2. Add constructor helpers that keep `ApiOptions::new(port)` working for standalone API startup.
3. Generate an unguessable token when none is supplied. Use UUID v4 or stronger random bytes; do not use timestamps, ports, or predictable process data.
4. Manage an auth state in Rocket, e.g. `ApiAuthState { token: String }`.

For standalone `crates/api/src/main.rs`, either read `AGHUB_API_TOKEN` or generate a token and print a clear one-line message to stderr such as `AGHUB_API_TOKEN=<redacted in logs?>` only if the operator needs it. Do not emit the token through normal API responses.

**Verify**: `cargo test -p aghub-api auth_options -- --nocapture` after adding focused tests for token generation/config; expected exit 0.

### Step 2: Require the token on API routes

Implement a Rocket request guard, for example:

- Header accepted: `Authorization: Bearer <token>`.
- Optional compatibility header: `X-AGHUB-API-Token: <token>` if easier for desktop tests.
- Missing token returns HTTP 401 with code like `UNAUTHORIZED`.
- Wrong token returns HTTP 403 with code like `FORBIDDEN`.
- `OPTIONS` preflight should not require auth, but must still be restricted by CORS.

Apply the guard to all mounted `/api/v1` routes except `routes::preflight`. The explicit approach is to add an unused `_auth: ApiAuth` parameter to each handler. If you choose a less invasive global approach, prove with tests that every mounted route is protected.

Do not protect Rocket catchers.

**Verify**: Add tests in `crates/api/src/lib.rs`:

- Unauthorized `GET /api/v1/agents` returns 401.
- Wrong-token `GET /api/v1/agents` returns 403.
- Correct-token `GET /api/v1/agents` returns 200.

Run `cargo test -p aghub-api auth -- --exact` or the equivalent filter → exit 0.

### Step 3: Restrict CORS origins and headers

Replace `allowed_origins: All` with explicit origins:

- Desktop dev origin: `http://localhost:1420`.
- Tauri production origin(s) actually used by the app, if Rocket CORS sees one.
- Optional loopback origins needed by tests.

Keep methods limited to the mounted methods. Keep only necessary headers: `Authorization`, `X-AGHUB-API-Token` if used, `Accept`, and `Content-Type`.

Set `allow_credentials` to `false` unless there is a demonstrated requirement for cookies/credentialed browser requests. The token header is the credential.

Add CORS tests:

- Allowed origin preflight succeeds and includes an allow-origin header for the allowed origin.
- Disallowed origin preflight does not grant access.

**Verify**: `cargo test -p aghub-api cors -- --exact` or matching filter → exit 0.

### Step 4: Return token from the embedded Tauri server startup

In `crates/desktop/src-tauri/src/commands/server.rs`:

1. Replace `Result<u16, String>` with a serializable response, for example:
   `ServerInfo { port: u16, token: String }`.
2. Store both port and token in app state, or store a struct, so repeated `start_server` calls return the same token for the running server.
3. Pass the token into `aghub_api::start(ApiOptions { port, app_data_dir: Some(app_data_dir), auth_token: Some(token.clone()), allowed_origins: ... })`.
4. Do not log the token.

If `AppState` currently stores only `Option<u16>`, update it to store `Option<ServerInfo>` or a private struct. Keep the public Tauri response serializable.

**Verify**: `cargo test -p aghub-api` still exits 0, and `cargo check -p aghub-desktop` or `cargo check -p aghub-desktop --manifest-path crates/desktop/src-tauri/Cargo.toml` exits 0. Use the actual package name from `crates/desktop/src-tauri/Cargo.toml` if it differs.

### Step 5: Send the token from the desktop API client

In the desktop frontend:

1. Update `ServerContextValue` to include `token`.
2. Update `ServerProvider` so `invoke("start_server")` expects `{ port, token }`, then stores both in context.
3. Update wherever `createApi(baseUrl)` is called so it also receives the token.
4. In `createApi`, add the auth header to every request using `ky.create({ headers: { Authorization: `Bearer ${token}` } })` or a `beforeRequest` hook.

Do not store the token in local storage, Tauri store, logs, analytics, or URLs.

**Verify**: `cd crates/desktop && bun run typecheck` → exit 0.

### Step 6: Update tests from plan 001 to authenticate

Plan 001's route-level tests should now supply the correct token. Add a test helper to create a `Client` with a known token by passing `ApiOptions`/test build config, and a request helper that adds the auth header.

Ensure at least one mutation test proves missing auth fails before retrying with auth succeeds.

**Verify**: `cargo test -p aghub-api` → exit 0.

## Test plan

Add or update tests covering:

- Token generation/config behavior.
- Unauthorized, wrong-token, and authorized API access.
- CORS allowed and denied origins.
- Existing route mutation tests still pass when sending the token.
- Desktop TypeScript compiles with the new `{ port, token }` server shape.

## Done criteria

- [ ] Every `/api/v1` route except preflight requires a valid token.
- [ ] Missing and wrong tokens produce JSON errors with 401/403.
- [ ] CORS no longer uses `All` origins and no longer allows credentials unless explicitly justified in code comments/tests.
- [ ] Desktop obtains the token from `start_server` and sends it in an auth header.
- [ ] Token is not logged, persisted, or placed in URLs.
- [ ] `cargo test -p aghub-api` exits 0.
- [ ] `cd crates/desktop && bun run typecheck` exits 0.
- [ ] `cargo fmt --all -- --check` exits 0.
- [ ] `plans/README.md` row 002 is updated to DONE by the executor.

## STOP conditions

Stop and report back if:

- Rocket cannot support the chosen global auth mechanism and adding guards would require touching generated files or unrelated business logic beyond route signatures.
- The desktop app has no safe way to keep the token in memory only.
- A route must remain unauthenticated for a documented reason; list it and get review before exempting it.
- CORS production origins cannot be determined from current Tauri behavior.
- Any verification command fails twice after reasonable fixes.

## Maintenance notes

Future API routes must include the auth guard. Reviewers should check the route list in `crates/api/src/lib.rs` against the guard usage and should reject any new unauthenticated route unless it is intentionally public and documented.
