### PR TITLE
fix(core): preserve imported skill contents

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -451,6 +451,26 @@ mod tests {
 		client.delete(uri).header(auth_header()).dispatch()
 	}
 
+	fn write_import_skill(dir: &Path, name: &str, body: &str) {
+		std::fs::create_dir_all(dir).expect("skill dir");
+		std::fs::write(
+			dir.join("SKILL.md"),
+			format!(
+				"---\nname: {name}\ndescription: imported skill\n---\n\n{body}\n"
+			),
+		)
+		.expect("skill file");
+		std::fs::create_dir_all(dir.join("scripts")).expect("scripts dir");
+		std::fs::create_dir_all(dir.join("references"))
+			.expect("references dir");
+		std::fs::create_dir_all(dir.join("assets")).expect("assets dir");
+		std::fs::write(dir.join("scripts/setup.sh"), "echo setup")
+			.expect("script");
+		std::fs::write(dir.join("references/guide.md"), "# Guide")
+			.expect("guide");
+		std::fs::write(dir.join("assets/logo.txt"), "logo").expect("asset");
+	}
+
 	#[test]
 	fn auth_options_generate_distinct_tokens() {
 		let first = crate::auth::generate_auth_token();
@@ -663,6 +683,40 @@ mod tests {
 		let response = get_auth(&client, &uri);
 		assert_eq!(response.status(), Status::Ok);
 		assert_eq!(response_json(response), json!("# Body"));
+	}
+
+	#[test]
+	fn import_skill_route_preserves_body_and_resources() {
+		let app_data_dir = tempfile::tempdir().expect("app data dir");
+		let project_dir = tempfile::tempdir().expect("project dir");
+		let source_dir = tempfile::tempdir().expect("source dir");
+		let skill_dir = source_dir.path().join("imported-route");
+		write_import_skill(
+			&skill_dir,
+			"imported-route",
+			"# Route imported instructions",
+		);
+		let client = test_client(app_data_dir.path());
+		let query = project_query(project_dir.path());
+		let uri = format!("/api/v1/agents/claude/skills/import?{query}");
+
+		let response = post_json(
+			&client,
+			&uri,
+			json!({ "path": skill_dir.display().to_string() }),
+		);
+		assert_eq!(response.status(), Status::Ok);
+		let body = response_json(response);
+		assert_eq!(body["name"], "imported-route");
+
+		let target_dir =
+			project_dir.path().join(".claude/skills/imported-route");
+		let content =
+			std::fs::read_to_string(target_dir.join("SKILL.md")).unwrap();
+		assert!(content.contains("# Route imported instructions"));
+		assert!(target_dir.join("scripts/setup.sh").exists());
+		assert!(target_dir.join("references/guide.md").exists());
+		assert!(target_dir.join("assets/logo.txt").exists());
 	}
 
 	#[test]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,7 +13,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }
 toml = { workspace = true }
-tempfile = { workspace = true, optional = true }
+tempfile = { workspace = true }
 skill = { path = "../skill" }
 which = "8"
 log = "0.4.31"
@@ -25,4 +25,4 @@ tempfile = { workspace = true }
 [features]
 default = [ "testing" ]
 agent-validation = [  ]
-testing = [ "tempfile" ]
+testing = [  ]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -49,6 +49,11 @@ pub fn convert_skill(skill_pkg: skill::Skill) -> models::Skill {
 		}
 		_ => None,
 	};
+	let content = if skill_pkg.content.is_empty() {
+		None
+	} else {
+		Some(skill_pkg.content)
+	};
 
 	models::Skill {
 		name: skill_pkg.name,
@@ -56,7 +61,7 @@ pub fn convert_skill(skill_pkg: skill::Skill) -> models::Skill {
 		description: Some(skill_pkg.description),
 		author: skill_pkg.author,
 		version: skill_pkg.version,
-		content: None,
+		content,
 		tools: skill_pkg
 			.allowed_tools
 			.map(|t| t.split(',').map(|s| s.trim().to_string()).collect())

--- a/crates/core/src/manager/skill.rs
+++ b/crates/core/src/manager/skill.rs
@@ -5,9 +5,34 @@ use crate::{
 	models::Skill,
 };
 use log::{debug, info, warn};
-use skill::sanitize::sanitize_name;
-use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use skill::{sanitize::sanitize_name, SkillSource};
+use std::{
+	collections::{hash_map::DefaultHasher, BTreeMap},
+	hash::{Hash, Hasher},
+	path::{Path, PathBuf},
+};
+
+const MAX_STAGING_SAFE_NAME_BYTES: usize = 80;
+const MAX_UNPACKED_SKILL_SCAN_DEPTH: usize = 10;
+
+enum SkillImportSource {
+	Directory(PathBuf),
+	SkillMd(PathBuf),
+	Package {
+		root: PathBuf,
+		_temp_dir: tempfile::TempDir,
+	},
+}
+
+impl SkillImportSource {
+	fn root_path(&self) -> Option<&Path> {
+		match self {
+			SkillImportSource::Directory(root)
+			| SkillImportSource::Package { root, .. } => Some(root),
+			SkillImportSource::SkillMd(path) => path.parent(),
+		}
+	}
+}
 
 /// Resolve a source_path string (potentially with `~/` prefix) to an absolute PathBuf
 fn resolve_source_path(sp: &str) -> PathBuf {
@@ -82,6 +107,310 @@ fn remove_skill_path(
 		})?;
 	}
 	Ok(())
+}
+
+fn symlink_import_error(path: &Path) -> ConfigError {
+	ConfigError::InvalidConfig(format!(
+		"Refusing to copy symlink '{}'",
+		path.display()
+	))
+}
+
+fn unsupported_import_entry_error(path: &Path) -> ConfigError {
+	ConfigError::InvalidConfig(format!(
+		"Refusing to copy unsupported import entry '{}'",
+		path.display()
+	))
+}
+
+fn same_existing_path(left: &Path, right: &Path) -> bool {
+	if left == right {
+		return true;
+	}
+
+	match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+		(Ok(left), Ok(right)) => left == right,
+		_ => false,
+	}
+}
+
+fn should_skip_import_path(path: &Path, skip_paths: &[PathBuf]) -> bool {
+	skip_paths
+		.iter()
+		.any(|skip_path| same_existing_path(path, skip_path))
+}
+
+fn is_strict_ancestor(parent: &Path, child: &Path) -> bool {
+	let parent =
+		std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
+	let child =
+		std::fs::canonicalize(child).unwrap_or_else(|_| child.to_path_buf());
+	child.starts_with(&parent) && child != parent
+}
+
+fn copy_dir_recursive(
+	from: &Path,
+	to: &Path,
+	skip_paths: &[PathBuf],
+) -> Result<()> {
+	let metadata = std::fs::symlink_metadata(from)?;
+	if metadata.file_type().is_symlink() {
+		return Err(symlink_import_error(from));
+	}
+	if !metadata.is_dir() {
+		return Err(unsupported_import_entry_error(from));
+	}
+
+	std::fs::create_dir_all(to)?;
+	for entry in std::fs::read_dir(from)? {
+		let entry = entry?;
+		let from_path = entry.path();
+		let to_path = to.join(entry.file_name());
+		let file_type = entry.file_type()?;
+		if file_type.is_symlink() {
+			return Err(symlink_import_error(&from_path));
+		}
+		if should_skip_import_path(&from_path, skip_paths) {
+			continue;
+		}
+		if file_type.is_dir() {
+			copy_dir_recursive(&from_path, &to_path, skip_paths)?;
+		} else if file_type.is_file() {
+			std::fs::copy(&from_path, &to_path)?;
+		} else {
+			return Err(unsupported_import_entry_error(&from_path));
+		}
+	}
+	Ok(())
+}
+
+fn cleanup_import_path(path: &Path) {
+	if let Ok(metadata) = std::fs::symlink_metadata(path) {
+		let result = if metadata.file_type().is_symlink() {
+			std::fs::remove_file(path)
+		} else if metadata.is_dir() {
+			std::fs::remove_dir_all(path)
+		} else {
+			std::fs::remove_file(path)
+		};
+		let _ = result;
+	}
+}
+
+fn copy_skill_md_with_resources(
+	from: &Path,
+	to: &Path,
+	skip_paths: &[PathBuf],
+) -> Result<()> {
+	let metadata = std::fs::symlink_metadata(from)?;
+	if metadata.file_type().is_symlink() {
+		return Err(symlink_import_error(from));
+	}
+	if !metadata.is_file() {
+		return Err(unsupported_import_entry_error(from));
+	}
+
+	std::fs::create_dir_all(to)?;
+	std::fs::copy(from, to.join("SKILL.md"))?;
+	if let Some(parent) = from.parent() {
+		for dir_name in ["scripts", "references", "assets"] {
+			let resource_dir = parent.join(dir_name);
+			match std::fs::symlink_metadata(&resource_dir) {
+				Ok(metadata) if metadata.file_type().is_symlink() => {
+					return Err(symlink_import_error(&resource_dir));
+				}
+				Ok(metadata) if metadata.is_dir() => {
+					copy_dir_recursive(
+						&resource_dir,
+						&to.join(dir_name),
+						skip_paths,
+					)?;
+				}
+				Ok(_) => {}
+				Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+				Err(e) => return Err(ConfigError::Io(e)),
+			}
+		}
+	}
+	Ok(())
+}
+
+fn copy_import_source(
+	source: &SkillImportSource,
+	to: &Path,
+	skip_paths: &[PathBuf],
+) -> Result<()> {
+	match source {
+		SkillImportSource::Directory(root)
+		| SkillImportSource::Package { root, .. } => {
+			copy_dir_recursive(root, to, skip_paths)
+		}
+		SkillImportSource::SkillMd(path) => {
+			copy_skill_md_with_resources(path, to, skip_paths)
+		}
+	}
+}
+
+fn staged_import_dir(parent: &Path, safe_name: &str) -> PathBuf {
+	let now = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.map(|duration| duration.as_nanos())
+		.unwrap_or_default();
+	let safe_name = staging_safe_name(safe_name);
+	parent.join(format!(".aghub-import-{safe_name}-{now}"))
+}
+
+fn staging_safe_name(safe_name: &str) -> String {
+	if safe_name.len() <= MAX_STAGING_SAFE_NAME_BYTES {
+		return safe_name.to_string();
+	}
+
+	let mut hasher = DefaultHasher::new();
+	safe_name.hash(&mut hasher);
+	let digest = format!("{:016x}", hasher.finish());
+	let mut prefix = String::new();
+	for ch in safe_name.chars() {
+		if prefix.len() + ch.len_utf8() > MAX_STAGING_SAFE_NAME_BYTES {
+			break;
+		}
+		prefix.push(ch);
+	}
+	format!("{prefix}-{digest}")
+}
+
+fn copy_import_source_staged(
+	source: &SkillImportSource,
+	target_dir: &Path,
+) -> Result<()> {
+	let parent = target_dir.parent().ok_or_else(|| {
+		ConfigError::InvalidConfig(format!(
+			"Skill target '{}' has no parent",
+			target_dir.display()
+		))
+	})?;
+	std::fs::create_dir_all(parent)?;
+	let safe_name = target_dir
+		.file_name()
+		.and_then(|name| name.to_str())
+		.unwrap_or("skill");
+	let staged = staged_import_dir(parent, safe_name);
+	cleanup_import_path(&staged);
+
+	let mut skip_paths = vec![staged.clone()];
+	if let Some(source_root) = source.root_path() {
+		if is_strict_ancestor(source_root, parent) {
+			skip_paths.push(parent.to_path_buf());
+		}
+	}
+
+	if let Err(e) = copy_import_source(source, &staged, &skip_paths) {
+		cleanup_import_path(&staged);
+		return Err(e);
+	}
+
+	if let Err(e) = std::fs::rename(&staged, target_dir) {
+		cleanup_import_path(&staged);
+		return Err(ConfigError::Io(e));
+	}
+
+	Ok(())
+}
+
+fn find_unpacked_skill_root(
+	unpack_dir: &Path,
+	skill_name: &str,
+) -> Result<PathBuf> {
+	let mut skill_dirs = Vec::new();
+	collect_unpacked_skill_roots(unpack_dir, 0, &mut skill_dirs).map_err(
+		|e| {
+			ConfigError::InvalidConfig(format!(
+				"Failed to scan unpacked skill package: {e}"
+			))
+		},
+	)?;
+	let matches = skill_dirs
+		.into_iter()
+		.filter(|dir| {
+			skill::parser::parse_skill_dir(dir)
+				.map(|skill| skill.name == skill_name)
+				.unwrap_or(false)
+		})
+		.collect::<Vec<_>>();
+
+	match matches.as_slice() {
+		[root] => Ok(root.clone()),
+		[] => Err(ConfigError::InvalidConfig(format!(
+			"Unpacked skill package did not contain skill '{skill_name}'"
+		))),
+		_ => Err(ConfigError::InvalidConfig(format!(
+			"Unpacked skill package contains multiple roots named \
+			 '{skill_name}'"
+		))),
+	}
+}
+
+fn has_skill_md_file(dir: &Path) -> bool {
+	["SKILL.md", "skill.md"]
+		.iter()
+		.any(|name| dir.join(name).is_file())
+}
+
+fn collect_unpacked_skill_roots(
+	dir: &Path,
+	depth: usize,
+	out: &mut Vec<PathBuf>,
+) -> std::io::Result<()> {
+	if depth > MAX_UNPACKED_SKILL_SCAN_DEPTH {
+		return Ok(());
+	}
+
+	if has_skill_md_file(dir) {
+		out.push(dir.to_path_buf());
+	}
+	if depth == MAX_UNPACKED_SKILL_SCAN_DEPTH {
+		return Ok(());
+	}
+
+	for entry in std::fs::read_dir(dir)? {
+		let entry = entry?;
+		let path = entry.path();
+		let metadata = std::fs::symlink_metadata(&path)?;
+		if metadata.file_type().is_symlink() {
+			continue;
+		}
+		if metadata.is_dir() {
+			collect_unpacked_skill_roots(&path, depth + 1, out)?;
+		}
+	}
+	Ok(())
+}
+
+fn import_source_from_parsed(
+	path: &Path,
+	source: &SkillSource,
+	skill_name: &str,
+) -> Result<SkillImportSource> {
+	match source {
+		SkillSource::Directory(root) => {
+			Ok(SkillImportSource::Directory(root.clone()))
+		}
+		SkillSource::SkillMd(skill_md) => {
+			Ok(SkillImportSource::SkillMd(skill_md.clone()))
+		}
+		SkillSource::SkillFile(_) | SkillSource::ZipFile(_) => {
+			let temp_dir = tempfile::TempDir::new().map_err(ConfigError::Io)?;
+			skill::package::unpack(path, temp_dir.path()).map_err(|e| {
+				ConfigError::InvalidConfig(format!(
+					"Failed to unpack skill package: {e}"
+				))
+			})?;
+			let root = find_unpacked_skill_root(temp_dir.path(), skill_name)?;
+			Ok(SkillImportSource::Package {
+				root,
+				_temp_dir: temp_dir,
+			})
+		}
+	}
 }
 
 impl ConfigManager {
@@ -303,8 +632,49 @@ impl ConfigManager {
 		let skill_pkg = skill::parser::parse(path).map_err(|e| {
 			ConfigError::InvalidConfig(format!("Failed to parse skill: {e}"))
 		})?;
-		let skill = convert_skill(skill_pkg);
-		self.add_skill(skill.clone())?;
+		let source = import_source_from_parsed(
+			path,
+			&skill_pkg.source,
+			&skill_pkg.name,
+		)?;
+		let mut skill = convert_skill(skill_pkg);
+		let target_dir = self.target_skills_dir().ok_or_else(|| {
+			ConfigError::InvalidConfig(
+				"Agent does not support persistent skill creation \
+				 in the current scope"
+					.into(),
+			)
+		})?;
+		let safe_name = sanitize_name(&skill.name);
+		let skill_dir = target_dir.join(&safe_name);
+		let agent_name = self.adapter.name().to_string();
+
+		{
+			let config = self.config_mut()?;
+			if config.skills.iter().any(|s| s.name == skill.name) {
+				return Err(ConfigError::resource_exists("skill", &skill.name));
+			}
+			if skill_dir.exists() {
+				return Err(ConfigError::resource_exists(
+					"skill target",
+					skill_dir.display().to_string(),
+				));
+			}
+		}
+
+		info!(
+			"importing skill '{}' from '{}' for agent '{}'",
+			skill.name,
+			path.display(),
+			agent_name
+		);
+		copy_import_source_staged(&source, &skill_dir)?;
+
+		skill.source_path =
+			Some(skill_dir.join("SKILL.md").to_string_lossy().to_string());
+		skill.canonical_path = None;
+		self.config_mut()?.skills.push(skill.clone());
+		self.save_current()?;
 		Ok(skill)
 	}
 
@@ -446,5 +816,16 @@ mod tests {
 		.expect("Should produce valid YAML");
 		assert_eq!(reparsed["version"], "123");
 		assert_eq!(reparsed["author"], "true");
+	}
+
+	#[test]
+	fn staged_import_dir_bounds_long_safe_name() {
+		let safe_name = "a".repeat(300);
+		let staged = staged_import_dir(Path::new("/tmp"), &safe_name);
+		let file_name = staged.file_name().unwrap().to_string_lossy();
+
+		assert!(file_name.starts_with(".aghub-import-"));
+		assert!(file_name.len() < 255);
+		assert!(file_name.len() < safe_name.len());
 	}
 }

--- a/crates/core/tests/test_agent_paths.rs
+++ b/crates/core/tests/test_agent_paths.rs
@@ -5,6 +5,44 @@
 use aghub_agents::agents::{amp, cursor, kimi, openclaw, opencode, pi};
 use std::path::{Path, PathBuf};
 
+fn write_import_skill(dir: &Path, name: &str, body: &str) {
+	std::fs::create_dir_all(dir).unwrap();
+	std::fs::write(
+		dir.join("SKILL.md"),
+		format!(
+			"---\nname: {name}\ndescription: imported skill\n---\n\n{body}\n"
+		),
+	)
+	.unwrap();
+}
+
+fn write_import_resources(dir: &Path) {
+	std::fs::create_dir_all(dir.join("scripts")).unwrap();
+	std::fs::create_dir_all(dir.join("references")).unwrap();
+	std::fs::create_dir_all(dir.join("assets")).unwrap();
+	std::fs::write(dir.join("scripts/setup.sh"), "echo setup").unwrap();
+	std::fs::write(dir.join("references/guide.md"), "# Guide").unwrap();
+	std::fs::write(dir.join("assets/logo.txt"), "logo").unwrap();
+}
+
+fn contains_entry_named_with_prefix(root: &Path, prefix: &str) -> bool {
+	let Ok(entries) = std::fs::read_dir(root) else {
+		return false;
+	};
+	for entry in entries.flatten() {
+		if entry.file_name().to_string_lossy().starts_with(prefix) {
+			return true;
+		}
+		let path = entry.path();
+		if entry.file_type().map(|t| t.is_dir()).unwrap_or(false)
+			&& contains_entry_named_with_prefix(&path, prefix)
+		{
+			return true;
+		}
+	}
+	false
+}
+
 // ─── XDG config path tests (xdg-config-paths.test.ts) ───────────────────────
 
 #[test]
@@ -302,4 +340,254 @@ fn test_delete_skill_with_slash_removes_sanitized_directory() {
 		!skill_dir.exists(),
 		"Sanitized directory should be removed on delete"
 	);
+}
+
+#[test]
+fn skill_import_directory_preserves_body_and_resources() {
+	let test =
+		aghub_core::testing::TestConfig::new(aghub_core::AgentType::Claude)
+			.unwrap();
+	let source_dir = test.temp_dir().join("source/imported-skill");
+	write_import_skill(
+		&source_dir,
+		"imported-skill",
+		"# Real imported instructions",
+	);
+	write_import_resources(&source_dir);
+
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+	let imported = manager.add_skill_from_path(&source_dir).unwrap();
+
+	assert_eq!(imported.name, "imported-skill");
+	assert!(imported
+		.content
+		.as_deref()
+		.unwrap()
+		.contains("# Real imported instructions"));
+	let target_dir = test.skills_dir().join("imported-skill");
+	let target_content =
+		std::fs::read_to_string(target_dir.join("SKILL.md")).unwrap();
+	assert!(target_content.contains("# Real imported instructions"));
+	assert!(target_dir.join("scripts/setup.sh").exists());
+	assert!(target_dir.join("references/guide.md").exists());
+	assert!(target_dir.join("assets/logo.txt").exists());
+
+	let mut reloaded = test.create_manager();
+	reloaded.load().unwrap();
+	let loaded = reloaded.get_skill("imported-skill").unwrap();
+	assert!(loaded.source_path.as_deref().unwrap().contains("SKILL.md"));
+	assert_eq!(
+		reloaded
+			.config()
+			.unwrap()
+			.skills
+			.iter()
+			.filter(|skill| skill.name == "imported-skill")
+			.count(),
+		1
+	);
+}
+
+#[test]
+fn skill_import_lowercase_skill_md_normalizes_target_source_path() {
+	let test =
+		aghub_core::testing::TestConfig::new(aghub_core::AgentType::Claude)
+			.unwrap();
+	let source_dir = test.temp_dir().join("source/lower-skill");
+	std::fs::create_dir_all(&source_dir).unwrap();
+	std::fs::write(
+		source_dir.join("skill.md"),
+		"---\nname: lower-skill\ndescription: lower file\n---\n\nbody\n",
+	)
+	.unwrap();
+
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+	manager
+		.add_skill_from_path(&source_dir.join("skill.md"))
+		.unwrap();
+
+	let target_dir = test.skills_dir().join("lower-skill");
+	let target_names = std::fs::read_dir(&target_dir)
+		.unwrap()
+		.map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+		.collect::<Vec<_>>();
+	assert!(target_names.iter().any(|name| name == "SKILL.md"));
+	assert!(!target_names.iter().any(|name| name == "skill.md"));
+
+	let mut reloaded = test.create_manager();
+	reloaded.load().unwrap();
+	let loaded = reloaded.get_skill("lower-skill").unwrap();
+	let source_path = PathBuf::from(loaded.source_path.as_ref().unwrap());
+	assert_eq!(source_path.file_name().unwrap(), "SKILL.md");
+}
+
+#[test]
+fn skill_import_ancestor_source_skips_destination_skills_dir() {
+	let temp = tempfile::TempDir::new().unwrap();
+	let project = temp.path().join("project");
+	write_import_skill(
+		&project,
+		"project-root-skill",
+		"# Project root instructions",
+	);
+
+	let mut manager = aghub_core::ConfigManager::new(
+		aghub_core::create_adapter(aghub_core::AgentType::Claude),
+		false,
+		Some(&project),
+	);
+	manager.init_empty_config();
+	let imported = manager.add_skill_from_path(&project).unwrap();
+
+	assert_eq!(imported.name, "project-root-skill");
+	let target_dir = project.join(".claude/skills/project-root-skill");
+	let target_content =
+		std::fs::read_to_string(target_dir.join("SKILL.md")).unwrap();
+	assert!(target_content.contains("# Project root instructions"));
+	assert!(
+		!target_dir.join(".claude/skills").exists(),
+		"Destination skills dir should not be copied into imported skill"
+	);
+	assert!(
+		!contains_entry_named_with_prefix(&target_dir, ".aghub-import-"),
+		"Staging directory should not be copied into imported skill"
+	);
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_import_directory_rejects_symlinked_file() {
+	let test =
+		aghub_core::testing::TestConfig::new(aghub_core::AgentType::Claude)
+			.unwrap();
+	let source_dir = test.temp_dir().join("source/link-skill");
+	write_import_skill(&source_dir, "link-skill", "body");
+	std::fs::create_dir_all(source_dir.join("scripts")).unwrap();
+	let secret_path = test.temp_dir().join("secret.txt");
+	std::fs::write(&secret_path, "secret").unwrap();
+	std::os::unix::fs::symlink(
+		&secret_path,
+		source_dir.join("scripts/leak.txt"),
+	)
+	.unwrap();
+
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+	let error = manager.add_skill_from_path(&source_dir).unwrap_err();
+
+	assert!(matches!(
+		error,
+		aghub_core::ConfigError::InvalidConfig(message)
+			if message.contains("symlink")
+	));
+	assert!(!test.skills_dir().join("link-skill").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_import_skill_md_rejects_symlinked_resource_dir() {
+	let test =
+		aghub_core::testing::TestConfig::new(aghub_core::AgentType::Claude)
+			.unwrap();
+	let source_dir = test.temp_dir().join("source/resource-link-skill");
+	write_import_skill(&source_dir, "resource-link-skill", "body");
+	let outside_assets = test.temp_dir().join("outside-assets");
+	std::fs::create_dir_all(&outside_assets).unwrap();
+	std::fs::write(outside_assets.join("secret.txt"), "secret").unwrap();
+	std::os::unix::fs::symlink(&outside_assets, source_dir.join("assets"))
+		.unwrap();
+
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+	let error = manager
+		.add_skill_from_path(&source_dir.join("SKILL.md"))
+		.unwrap_err();
+
+	assert!(matches!(
+		error,
+		aghub_core::ConfigError::InvalidConfig(message)
+			if message.contains("symlink")
+	));
+	assert!(!test.skills_dir().join("resource-link-skill").exists());
+}
+
+#[test]
+fn skill_import_package_preserves_body_and_resources() {
+	let test =
+		aghub_core::testing::TestConfig::new(aghub_core::AgentType::Claude)
+			.unwrap();
+	let source_dir = test.temp_dir().join("source/package-skill");
+	write_import_skill(
+		&source_dir,
+		"package-skill",
+		"# Packaged imported instructions",
+	);
+	write_import_resources(&source_dir);
+	let package_path = test.temp_dir().join("package-skill.skill");
+	skill::package::pack(&source_dir, &package_path).unwrap();
+
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+	manager.add_skill_from_path(&package_path).unwrap();
+
+	let target_dir = test.skills_dir().join("package-skill");
+	let target_content =
+		std::fs::read_to_string(target_dir.join("SKILL.md")).unwrap();
+	assert!(target_content.contains("# Packaged imported instructions"));
+	assert!(target_dir.join("scripts/setup.sh").exists());
+	assert!(target_dir.join("references/guide.md").exists());
+	assert!(target_dir.join("assets/logo.txt").exists());
+}
+
+#[test]
+fn skill_import_package_rejects_duplicate_same_name_roots() {
+	let test =
+		aghub_core::testing::TestConfig::new(aghub_core::AgentType::Claude)
+			.unwrap();
+	let source_dir = test.temp_dir().join("source/duplicate-package");
+	write_import_skill(&source_dir, "duplicate-package", "# Root");
+	write_import_skill(
+		&source_dir.join("nested"),
+		"duplicate-package",
+		"# Nested",
+	);
+	let package_path = test.temp_dir().join("duplicate-package.skill");
+	skill::package::pack(&source_dir, &package_path).unwrap();
+
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+	let error = manager.add_skill_from_path(&package_path).unwrap_err();
+
+	assert!(matches!(
+		error,
+		aghub_core::ConfigError::InvalidConfig(message)
+			if message.contains("multiple roots")
+	));
+	assert!(!test.skills_dir().join("duplicate-package").exists());
+}
+
+#[test]
+fn skill_import_rejects_sanitized_target_collision() {
+	let test =
+		aghub_core::testing::TestConfig::new(aghub_core::AgentType::Claude)
+			.unwrap();
+	let existing_dir = test.skills_dir().join("owner-repo");
+	write_import_skill(&existing_dir, "existing", "existing body");
+	let source_dir = test.temp_dir().join("source/owner-repo");
+	write_import_skill(&source_dir, "owner/repo", "new body");
+
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+	let error = manager.add_skill_from_path(&source_dir).unwrap_err();
+
+	assert!(matches!(
+		error,
+		aghub_core::ConfigError::ResourceExists { .. }
+	));
+	let target_content =
+		std::fs::read_to_string(existing_dir.join("SKILL.md")).unwrap();
+	assert!(target_content.contains("existing body"));
+	assert!(!target_content.contains("new body"));
 }


### PR DESCRIPTION
# Plan 004: Preserve local skill imports, including body and resources

> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving to the next step. If anything in the STOP conditions section occurs, stop and report — do not improvise. When done, update the status row for this plan in `plans/README.md` unless a reviewer told you they maintain the index.
>
> **Drift check (run first)**: `git diff --stat b014ccbd..HEAD -- crates/core/src/lib.rs crates/core/src/manager/skill.rs crates/skill/src/parser.rs crates/skill/src/package.rs crates/core/tests crates/api/src/routes/skills.rs`
> If any in-scope file changed since this plan was written, compare the Current state excerpts against the live code before proceeding; on mismatch, treat it as a STOP condition.

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/003-constrain-skill-paths.md`
- **Category**: bug
- **Planned at**: commit `b014ccbd`, 2026-06-13

## Why this matters

Aghub advertises importing `.skill` packages and `SKILL.md`-based local skills, but the current core import path parses metadata and then creates a newly formatted skill file. The parsed body is dropped, and resource directories such as `scripts/`, `references/`, and `assets/` are not copied for the local import path. Users can import a valid skill and end up with a placeholder instead of the actual instructions and supporting files.

## Current state

Relevant files:

- `crates/skill/src/parser.rs` — parser preserves body/resource lists in `skill::Skill`.
- `crates/core/src/lib.rs` — converts `skill::Skill` into `aghub_core::models::Skill` but currently drops content.
- `crates/core/src/manager/skill.rs` — `add_skill_from_path` parses then calls `add_skill`, which writes a regenerated `SKILL.md`.
- `crates/skill/src/package.rs` — can unpack `.skill`/`.zip` archives.
- `crates/api/src/routes/skills.rs` — import route calls `manager.add_skill_from_path` and writes install locks.

Current excerpts to verify before editing:

```rust
// crates/skill/src/parser.rs:248
Ok(Skill {
	name: name.to_string(),
	description: description.to_string(),
	license,
	compatibility,
	allowed_tools,
	author,
	version,
	content: body,
```

```rust
// crates/core/src/lib.rs:35
pub fn convert_skill(skill_pkg: skill::Skill) -> models::Skill {
```

```rust
// crates/core/src/lib.rs:59
		content: None,
```

```rust
// crates/core/src/manager/skill.rs:88
pub fn add_skill(&mut self, skill: Skill) -> Result<()> {
```

```rust
// crates/core/src/manager/skill.rs:101
let content = format_skill(&skill, None);
std::fs::write(skill_dir.join("SKILL.md"), content)?;
```

```rust
// crates/core/src/manager/skill.rs:297
pub fn add_skill_from_path(&mut self, path: &Path) -> Result<Skill> {
```

Repo conventions:

- Core errors use `ConfigError`/`Result` from `crates/core/src/errors.rs`.
- Skill directory names are sanitized with `skill::sanitize::sanitize_name`.
- Existing tests under `crates/core/tests` use temp dirs and `ConfigManager` with test roots.

## Commands you will need

| Purpose | Command | Expected on success |
| ------- | ------- | ------------------- |
| Core skill tests | `cargo test -p aghub-core skill_import` | exit 0; new import tests pass |
| Skill package tests, if package helpers change | `cargo test -p skill package` | exit 0 |
| API tests | `cargo test -p aghub-api import_skill` | exit 0 if API route tests are added/changed |
| Format check | `cargo fmt --all -- --check` | exit 0 |

## Scope

**In scope**:

- `crates/core/src/lib.rs`.
- `crates/core/src/manager/skill.rs`.
- `crates/skill/src/package.rs` only if a safer unpack/copy helper is needed.
- Tests under `crates/core/tests` or `crates/core/src/manager/skill.rs`.
- `crates/api/src/routes/skills.rs` only if import route behavior must pass additional context to core.

**Out of scope**:

- Changing the `.skill` archive format.
- Changing marketplace/git install behavior except where it reuses the same core import helper.
- Rewriting lock-file hashing; that is a separate finding.
- Broad path-containment policy; that belongs to plan 003.

## Git workflow

- Branch: `advisor/004-preserve-skill-imports`.
- Commit message: `fix(core): preserve imported skill contents`.
- Do not push or open a PR unless instructed.

## Steps

### Step 1: Preserve parsed body in `convert_skill`

In `crates/core/src/lib.rs`, change `convert_skill` so `models::Skill.content` receives the parser body:

- `content: Some(skill_pkg.content)` when the body is non-empty.
- Prefer `None` only if the parsed body is empty and existing formatting semantics expect that.

Keep metadata conversion behavior unchanged.

Add or update a unit test for `convert_skill` if a suitable test module exists; otherwise cover this through `add_skill_from_path` tests in step 3.

**Verify**: `cargo test -p aghub-core convert_skill` or the nearest focused filter → exit 0.

### Step 2: Add a full-source import path in `ConfigManager`

Modify `ConfigManager::add_skill_from_path` so local imports preserve resources:

1. Parse the source path first, as today, to validate metadata and get the skill name.
2. Compute the target directory with `target_skills_dir()/sanitize_name(skill.name)`.
3. Reject duplicates using both raw name and sanitized target path to avoid overwrites.
4. For a source directory, copy the whole skill root directory into the target directory, including `SKILL.md`, `scripts/`, `references/`, and `assets/`.
5. For a source `SKILL.md` file, copy at least that file into the target directory, preserving its body exactly. If sibling resource directories are discoverable from the `SKILL.md` parent, copy them too only when they are part of the skill root.
6. For `.skill`/`.zip`, unpack into a temp directory, locate the parsed skill root, then copy that root into the target directory. Use containment-safe unpack behavior from `skill::package::unpack`; if it is insufficient, add tests and harden it here rather than trusting archive paths.
7. After copying, set `source_path` to the new target `SKILL.md`, `canonical_path` to `None`, push the loaded skill into config, and save.

Do not call `add_skill` for local imports if doing so would regenerate the file and drop resources.

**Verify**: `cargo test -p aghub-core add_skill_from_path` → exit 0.

### Step 3: Add regression tests for directory import

Add a test named `skill_import_directory_preserves_body_and_resources` that:

1. Creates a temp source skill directory with:
   - `SKILL.md` containing frontmatter and a distinctive body, e.g. `# Real imported instructions`.
   - `scripts/setup.sh`.
   - `references/guide.md`.
   - `assets/logo.txt`.
2. Imports it with `ConfigManager::add_skill_from_path` into a temp project/global target supported by a test agent.
3. Reads the target `SKILL.md` and asserts the distinctive body is present.
4. Asserts the three resource files exist under the target directory.
5. Reloads the manager and asserts the skill appears once with the expected name and source path.

Use existing core tests such as `test_rename_skill_migrates_sanitized_directory` as style reference for temp filesystem assertions.

**Verify**: `cargo test -p aghub-core skill_import_directory_preserves_body_and_resources -- --exact` → exit 0.

### Step 4: Add regression tests for package import

Add tests for `.skill` or `.zip` package import:

1. Build a package using existing `skill::package::pack` test patterns or a small zip fixture in a temp dir.
2. Import the package with `add_skill_from_path`.
3. Assert body text and resource directories survive.
4. Assert unsafe archive paths, if package unpack is touched, are rejected and do not write outside the target temp dir.

**Verify**: `cargo test -p aghub-core skill_import_package_preserves_body_and_resources -- --exact` → exit 0.

### Step 5: Verify API import route still works

If plan 001 added route tests, extend or add an API route test for `POST /api/v1/agents/<agent>/skills/import` using a temp source directory. Assert the HTTP route persists the body/resources through the core path.

**Verify**: `cargo test -p aghub-api import_skill` → exit 0.

## Test plan

New tests should cover:

- Directory import preserves `SKILL.md` body.
- Directory import copies `scripts/`, `references/`, and `assets/`.
- `.skill`/`.zip` import preserves body/resources.
- Duplicate imports do not overwrite an existing sanitized target directory.
- API import route uses the preserving path.

## Done criteria

- [ ] `convert_skill` no longer drops parsed body content.
- [ ] `add_skill_from_path` copies/unpacks the full skill root instead of regenerating a placeholder.
- [ ] Imported resources under `scripts/`, `references/`, and `assets/` survive.
- [ ] Duplicate raw names and sanitized target collisions are rejected before writing.
- [ ] `cargo test -p aghub-core skill_import` exits 0.
- [ ] `cargo test -p aghub-api import_skill` exits 0 if API tests changed.
- [ ] `cargo fmt --all -- --check` exits 0.
- [ ] `plans/README.md` row 004 is updated to DONE by the executor.

## STOP conditions

Stop and report back if:

- `.skill`/`.zip` archives can contain multiple skill roots and the correct root cannot be determined from existing parser data.
- Preserving resource directories requires copying files outside the parsed skill root.
- Existing public behavior intentionally regenerated imports and a compatibility choice is needed.
- Any verification command fails twice after reasonable fixes.

## Maintenance notes

Future import sources should go through the preserving import helper. Reviewers should inspect archive extraction and duplicate-target behavior carefully because this path writes user-controlled files into agent skill directories.
