### PR TITLE
fix(plugins): validate archive extraction paths

### DIFF
--- a/crates/cc-plugins/src/installer/git.rs
+++ b/crates/cc-plugins/src/installer/git.rs
@@ -2,10 +2,35 @@
 
 use anyhow::{Context, Result};
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 pub struct GitBasedInstaller {
 	client: reqwest::Client,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SafeArchivePath {
+	archive_path: String,
+}
+
+impl SafeArchivePath {
+	fn new(parts: Vec<String>) -> Self {
+		Self {
+			archive_path: parts.join("/"),
+		}
+	}
+
+	fn as_archive_path(&self) -> &str {
+		&self.archive_path
+	}
+
+	fn to_target_path(&self) -> PathBuf {
+		let mut target_path = PathBuf::new();
+		for part in self.archive_path.split('/') {
+			target_path.push(part);
+		}
+		target_path
+	}
 }
 
 pub(crate) fn build_http_client(timeout_secs: u64) -> Result<reqwest::Client> {
@@ -14,6 +39,134 @@ pub(crate) fn build_http_client(timeout_secs: u64) -> Result<reqwest::Client> {
 		.timeout(std::time::Duration::from_secs(timeout_secs))
 		.build()
 		.context("Failed to create HTTP client")
+}
+
+fn safe_archive_relative_path(path: &Path) -> Result<SafeArchivePath> {
+	if path.as_os_str().is_empty() || path.is_absolute() {
+		anyhow::bail!("Unsafe archive path: {}", path.display());
+	}
+
+	let mut parts = Vec::new();
+	for component in path.components() {
+		match component {
+			Component::Normal(part) => {
+				let part = part.to_str().ok_or_else(|| {
+					anyhow::anyhow!(
+						"Archive path is not valid UTF-8: {}",
+						path.display()
+					)
+				})?;
+				if part.is_empty() {
+					anyhow::bail!(
+						"Unsafe empty archive path component: {}",
+						path.display()
+					);
+				}
+				parts.push(part.to_string());
+			}
+			Component::CurDir => {}
+			Component::ParentDir
+			| Component::RootDir
+			| Component::Prefix(_) => {
+				anyhow::bail!("Unsafe archive path: {}", path.display());
+			}
+		}
+	}
+
+	if parts.is_empty() {
+		anyhow::bail!("Unsafe empty archive path: {}", path.display());
+	}
+
+	Ok(SafeArchivePath::new(parts))
+}
+
+fn ensure_safe_entry_type(
+	entry_type: tar::EntryType,
+	path: &str,
+) -> Result<()> {
+	if entry_type.is_file() || entry_type.is_dir() {
+		return Ok(());
+	}
+
+	anyhow::bail!("Unsafe archive entry type {:?} for {}", entry_type, path)
+}
+
+fn ensure_canonical_child(child: &Path, root: &Path) -> Result<()> {
+	if child == root || child.starts_with(root) {
+		return Ok(());
+	}
+
+	anyhow::bail!(
+		"Archive entry target escaped extraction root: {}",
+		child.display()
+	)
+}
+
+fn ensure_target_parent_safe(
+	target_path: &Path,
+	canonical_root: &Path,
+) -> Result<()> {
+	if let Ok(metadata) = std::fs::symlink_metadata(target_path) {
+		if metadata.file_type().is_symlink() {
+			anyhow::bail!(
+				"Archive entry target is a symlink: {}",
+				target_path.display()
+			);
+		}
+	}
+
+	let parent = target_path.parent().ok_or_else(|| {
+		anyhow::anyhow!(
+			"Archive entry target has no parent: {}",
+			target_path.display()
+		)
+	})?;
+	std::fs::create_dir_all(parent)?;
+	let canonical_parent = parent.canonicalize().with_context(|| {
+		format!("Failed to canonicalize parent {}", parent.display())
+	})?;
+	ensure_canonical_child(&canonical_parent, canonical_root)
+}
+
+fn reset_extraction_target(target_dir: &Path) -> Result<()> {
+	match std::fs::symlink_metadata(target_dir) {
+		Ok(metadata) => {
+			if metadata.file_type().is_symlink() {
+				anyhow::bail!(
+					"Extraction target is a symlink: {}",
+					target_dir.display()
+				);
+			}
+			if !metadata.is_dir() {
+				anyhow::bail!(
+					"Extraction target is not a directory: {}",
+					target_dir.display()
+				);
+			}
+			std::fs::remove_dir_all(target_dir).with_context(|| {
+				format!(
+					"Failed to clear extraction target {}",
+					target_dir.display()
+				)
+			})?;
+		}
+		Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+		Err(error) => {
+			return Err(error).with_context(|| {
+				format!(
+					"Failed to inspect extraction target {}",
+					target_dir.display()
+				)
+			});
+		}
+	}
+
+	std::fs::create_dir_all(target_dir).with_context(|| {
+		format!(
+			"Failed to create extraction target {}",
+			target_dir.display()
+		)
+	})
 }
 
 impl GitBasedInstaller {
@@ -89,22 +242,26 @@ impl GitBasedInstaller {
 		let mut archive = tar::Archive::new(tar);
 
 		let mut entry_errors = Vec::new();
-		let entries: Vec<_> = archive
-			.entries()
-			.context("Failed to read tarball entries - archive may be corrupted or not a valid gzip file")?
-			.filter_map(|e| {
-				match e {
-					Ok(entry) => Some(entry),
-					Err(err) => {
-						entry_errors.push(format!("{:?}", err));
-						None
-					}
+		let mut entries = Vec::new();
+		for entry in archive.entries().context(
+			"Failed to read tarball entries - archive may be corrupted or \
+			 not a valid gzip file",
+		)? {
+			let entry = match entry {
+				Ok(entry) => entry,
+				Err(err) => {
+					entry_errors.push(format!("{err:?}"));
+					continue;
 				}
-			})
-			.map(|e| e.path().map(|p| p.to_string_lossy().to_string()))
-			.filter_map(|p| p.ok())
-			.filter(|p| !p.contains("pax_global_header"))
-			.collect();
+			};
+			let path = entry.path().context("Failed to read tar entry path")?;
+			let path_str = path.to_string_lossy();
+			if path_str.contains("pax_global_header") {
+				continue;
+			}
+			let safe_path = safe_archive_relative_path(&path)?;
+			entries.push(safe_path.as_archive_path().to_string());
+		}
 
 		if entries.is_empty() {
 			let error_detail = if entry_errors.is_empty() {
@@ -131,13 +288,23 @@ impl GitBasedInstaller {
 		let extract_prefix = if subdir.is_empty() {
 			prefix.clone()
 		} else {
-			format!("{}{subdir}/", prefix)
+			let safe_subdir = safe_archive_relative_path(Path::new(subdir))?;
+			format!("{}{}/", prefix, safe_subdir.as_archive_path())
 		};
+		reset_extraction_target(target_dir)?;
+		let canonical_target_dir =
+			target_dir.canonicalize().with_context(|| {
+				format!(
+					"Failed to canonicalize extraction target {}",
+					target_dir.display()
+				)
+			})?;
 
 		for entry in archive.entries()? {
 			let mut entry = entry?;
 			let path = entry.path()?;
-			let path_str = path.to_string_lossy();
+			let safe_path = safe_archive_relative_path(&path)?;
+			let path_str = safe_path.as_archive_path();
 
 			if path_str.starts_with(&extract_prefix) {
 				let relative_path = path_str
@@ -148,15 +315,35 @@ impl GitBasedInstaller {
 					continue;
 				}
 
-				let target_path = target_dir.join(relative_path);
+				let relative_path =
+					safe_archive_relative_path(Path::new(relative_path))?;
+				let target_path =
+					target_dir.join(relative_path.to_target_path());
+				let entry_type = entry.header().entry_type();
+				ensure_safe_entry_type(
+					entry_type,
+					safe_path.as_archive_path(),
+				)?;
 
-				if entry.header().entry_type().is_dir() {
+				if entry_type.is_dir() {
 					std::fs::create_dir_all(&target_path)?;
+					let canonical_dir =
+						target_path.canonicalize().with_context(|| {
+							format!(
+								"Failed to canonicalize extracted directory {}",
+								target_path.display()
+							)
+						})?;
+					ensure_canonical_child(
+						&canonical_dir,
+						&canonical_target_dir,
+					)?;
 				} else {
-					if let Some(parent) = target_path.parent() {
-						std::fs::create_dir_all(parent)?;
-					}
-					entry.unpack(target_path)?;
+					ensure_target_parent_safe(
+						&target_path,
+						&canonical_target_dir,
+					)?;
+					entry.unpack(&target_path)?;
 				}
 			}
 		}
@@ -196,7 +383,97 @@ impl GitBasedInstaller {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use flate2::write::GzEncoder;
+	use flate2::Compression;
+	use std::io::Write;
+	use tar::Builder;
 	use tempfile::tempdir;
+
+	fn build_tarball<F>(write_entries: F) -> Vec<u8>
+	where
+		F: FnOnce(&mut Builder<&mut GzEncoder<Vec<u8>>>),
+	{
+		let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+		{
+			let mut tar = Builder::new(&mut encoder);
+			write_entries(&mut tar);
+			tar.finish().unwrap();
+		}
+		encoder.finish().unwrap()
+	}
+
+	fn append_file<W: Write>(tar: &mut Builder<W>, path: &str, content: &[u8]) {
+		let mut header = tar::Header::new_gnu();
+		header.set_size(content.len() as u64);
+		header.set_mode(0o644);
+		header.set_cksum();
+		tar.append_data(&mut header, path, content).unwrap();
+	}
+
+	fn append_raw_path_file<W: Write>(
+		tar: &mut Builder<W>,
+		path: &str,
+		content: &[u8],
+	) {
+		assert!(path.len() < 100);
+		let mut header = tar::Header::new_gnu();
+		header.set_size(content.len() as u64);
+		header.set_mode(0o644);
+		header.as_mut_bytes()[..path.len()].copy_from_slice(path.as_bytes());
+		header.set_cksum();
+		tar.append(&header, content).unwrap();
+	}
+
+	fn append_link<W: Write>(
+		tar: &mut Builder<W>,
+		entry_type: tar::EntryType,
+		path: &str,
+		target: &str,
+	) {
+		let mut header = tar::Header::new_gnu();
+		header.set_entry_type(entry_type);
+		header.set_size(0);
+		header.set_mode(0o777);
+		header.set_link_name(target).unwrap();
+		header.set_cksum();
+		tar.append_data(&mut header, path, std::io::empty())
+			.unwrap();
+	}
+
+	#[test]
+	fn safe_archive_relative_path_accepts_normal_paths() {
+		let path =
+			safe_archive_relative_path(Path::new("./repo-root/file.txt"))
+				.unwrap();
+		assert_eq!(path.as_archive_path(), "repo-root/file.txt");
+		assert_eq!(
+			path.to_target_path(),
+			PathBuf::from("repo-root").join("file.txt")
+		);
+	}
+
+	#[test]
+	fn safe_archive_relative_path_keeps_archive_separators() {
+		let path = safe_archive_relative_path(Path::new(
+			"repo-root/plugins/vercel/file.txt",
+		))
+		.unwrap();
+
+		assert_eq!(path.as_archive_path(), "repo-root/plugins/vercel/file.txt");
+	}
+
+	#[test]
+	fn safe_archive_relative_path_rejects_parent_escape() {
+		assert!(safe_archive_relative_path(Path::new("../escape")).is_err());
+		assert!(
+			safe_archive_relative_path(Path::new("repo/../escape")).is_err()
+		);
+	}
+
+	#[test]
+	fn safe_archive_relative_path_rejects_absolute_paths() {
+		assert!(safe_archive_relative_path(Path::new("/absolute")).is_err());
+	}
 
 	#[test]
 	fn test_find_common_prefix() {
@@ -215,15 +492,8 @@ mod tests {
 
 	#[test]
 	fn test_extract_tarball_from_repo_root() {
-		use flate2::write::GzEncoder;
-		use flate2::Compression;
-		use tar::Builder;
-
 		let temp_dir = tempdir().unwrap();
-
-		let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-		{
-			let mut tar = Builder::new(&mut encoder);
+		let bytes = build_tarball(|tar| {
 			let files = [
 				(
 					"repo-root-abc123/.claude-plugin/plugin.json",
@@ -234,16 +504,9 @@ mod tests {
 			];
 
 			for (path, content) in files {
-				let mut header = tar::Header::new_gnu();
-				header.set_size(content.len() as u64);
-				header.set_mode(0o644);
-				header.set_cksum();
-				tar.append_data(&mut header, path, content).unwrap();
+				append_file(tar, path, content);
 			}
-			tar.finish().unwrap();
-		}
-
-		let bytes = encoder.finish().unwrap();
+		});
 		let commit =
 			GitBasedInstaller::extract_tarball(&bytes, "", temp_dir.path())
 				.unwrap();
@@ -251,5 +514,177 @@ mod tests {
 		assert_eq!(commit, "abc123");
 		assert!(temp_dir.path().join(".claude-plugin/plugin.json").exists());
 		assert!(temp_dir.path().join("README.md").exists());
+	}
+
+	#[test]
+	fn extract_tarball_rejects_parent_directory_escape() {
+		let temp_dir = tempdir().unwrap();
+		let target_dir = temp_dir.path().join("target");
+		let bytes = build_tarball(|tar| {
+			append_file(
+				tar,
+				"repo-root-abc123/.claude-plugin/plugin.json",
+				br#"{"name":"repo-root"}"#,
+			);
+			append_raw_path_file(
+				tar,
+				"repo-root-abc123/../escape.txt",
+				b"escape",
+			);
+		});
+
+		let error = GitBasedInstaller::extract_tarball(&bytes, "", &target_dir)
+			.unwrap_err();
+
+		assert!(error.to_string().contains("Unsafe archive path"));
+		assert!(!temp_dir.path().join("escape.txt").exists());
+	}
+
+	#[test]
+	fn extract_tarball_rejects_absolute_paths() {
+		let temp_dir = tempdir().unwrap();
+		let bytes = build_tarball(|tar| {
+			append_file(
+				tar,
+				"repo-root-abc123/.claude-plugin/plugin.json",
+				br#"{"name":"repo-root"}"#,
+			);
+			append_raw_path_file(
+				tar,
+				"/repo-root-abc123/absolute.txt",
+				b"absolute",
+			);
+		});
+
+		let error =
+			GitBasedInstaller::extract_tarball(&bytes, "", temp_dir.path())
+				.unwrap_err();
+
+		assert!(error.to_string().contains("Unsafe archive path"));
+	}
+
+	#[test]
+	fn extract_tarball_rejects_symlink_entries() {
+		let temp_dir = tempdir().unwrap();
+		let bytes = build_tarball(|tar| {
+			append_file(
+				tar,
+				"repo-root-abc123/.claude-plugin/plugin.json",
+				br#"{"name":"repo-root"}"#,
+			);
+			append_link(
+				tar,
+				tar::EntryType::Symlink,
+				"repo-root-abc123/link",
+				"../../outside",
+			);
+		});
+
+		let error =
+			GitBasedInstaller::extract_tarball(&bytes, "", temp_dir.path())
+				.unwrap_err();
+
+		assert!(error.to_string().contains("Unsafe archive entry type"));
+		assert!(!temp_dir.path().join("link").exists());
+	}
+
+	#[test]
+	fn extract_tarball_rejects_hard_link_entries() {
+		let temp_dir = tempdir().unwrap();
+		let bytes = build_tarball(|tar| {
+			append_file(
+				tar,
+				"repo-root-abc123/.claude-plugin/plugin.json",
+				br#"{"name":"repo-root"}"#,
+			);
+			append_link(
+				tar,
+				tar::EntryType::Link,
+				"repo-root-abc123/hard-link",
+				"repo-root-abc123/.claude-plugin/plugin.json",
+			);
+		});
+
+		let error =
+			GitBasedInstaller::extract_tarball(&bytes, "", temp_dir.path())
+				.unwrap_err();
+
+		assert!(error.to_string().contains("Unsafe archive entry type"));
+		assert!(!temp_dir.path().join("hard-link").exists());
+	}
+
+	#[test]
+	fn extract_tarball_clears_partial_files_before_retry() {
+		let temp_dir = tempdir().unwrap();
+		let target_dir = temp_dir.path().join("target");
+		let bad_bytes = build_tarball(|tar| {
+			append_file(tar, "repo-root-bad123/old.txt", b"stale");
+			append_link(
+				tar,
+				tar::EntryType::Symlink,
+				"repo-root-bad123/link",
+				"../../outside",
+			);
+		});
+
+		let error =
+			GitBasedInstaller::extract_tarball(&bad_bytes, "", &target_dir)
+				.unwrap_err();
+
+		assert!(error.to_string().contains("Unsafe archive entry type"));
+		assert_eq!(
+			std::fs::read_to_string(target_dir.join("old.txt")).unwrap(),
+			"stale"
+		);
+
+		let good_bytes = build_tarball(|tar| {
+			append_file(
+				tar,
+				"repo-root-good456/new.txt",
+				b"fresh plugin content with enough unique text to pass the \
+				 tarball size guard after gzip compression",
+			);
+		});
+		let commit =
+			GitBasedInstaller::extract_tarball(&good_bytes, "", &target_dir)
+				.unwrap();
+
+		assert_eq!(commit, "good456");
+		assert!(!target_dir.join("old.txt").exists());
+		assert_eq!(
+			std::fs::read_to_string(target_dir.join("new.txt")).unwrap(),
+			"fresh plugin content with enough unique text to pass the \
+			 tarball size guard after gzip compression"
+		);
+	}
+
+	#[test]
+	fn extract_tarball_keeps_valid_subdir_extraction_working() {
+		let temp_dir = tempdir().unwrap();
+		let bytes = build_tarball(|tar| {
+			append_file(
+				tar,
+				"repo-root-abc123/plugins/vercel/.claude-plugin/plugin.json",
+				br#"{"name":"vercel"}"#,
+			);
+			append_file(
+				tar,
+				"repo-root-abc123/plugins/vercel/README.md",
+				b"# Vercel",
+			);
+			append_file(tar, "repo-root-abc123/other.txt", b"other");
+		});
+
+		let commit = GitBasedInstaller::extract_tarball(
+			&bytes,
+			"plugins/vercel",
+			temp_dir.path(),
+		)
+		.unwrap();
+
+		assert_eq!(commit, "abc123");
+		assert!(temp_dir.path().join(".claude-plugin/plugin.json").exists());
+		assert!(temp_dir.path().join("README.md").exists());
+		assert!(!temp_dir.path().join("other.txt").exists());
 	}
 }


### PR DESCRIPTION
# Plan 005: Make plugin archive extraction containment-safe

> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving to the next step. If anything in the STOP conditions section occurs, stop and report — do not improvise. When done, update the status row for this plan in `plans/README.md` unless a reviewer told you they maintain the index.
>
> **Drift check (run first)**: `git diff --stat b014ccbd..HEAD -- crates/cc-plugins/src/installer/git.rs crates/cc-plugins/src/installer/registry.rs crates/cc-plugins/src/discovery/marketplace.rs crates/cc-plugins/Cargo.toml`
> If any in-scope file changed since this plan was written, compare the Current state excerpts against the live code before proceeding; on mismatch, treat it as a STOP condition.

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: MED
- **Depends on**: `plans/003-constrain-skill-paths.md`
- **Category**: security
- **Planned at**: commit `b014ccbd`, 2026-06-13

## Why this matters

Plugin marketplace sources can point to repository archives. The current tar extraction loop builds a target path from archive-derived text and calls `entry.unpack(target_path)` without proving the result stays inside the extraction root. A malicious or compromised archive can attempt path traversal, absolute paths, hard links, or unsafe symlinks. This plan rejects unsafe entries and uses containment-safe extraction semantics before plugin manifests or installs consume the extracted files.

## Current state

Relevant files:

- `crates/cc-plugins/src/discovery/marketplace.rs` — marketplace JSON accepts `url` sources.
- `crates/cc-plugins/src/installer/registry.rs` — turns repository URLs into tarball URLs and calls extraction.
- `crates/cc-plugins/src/installer/git.rs` — downloads and extracts tarballs.

Current excerpts to verify before editing:

```rust
// crates/cc-plugins/src/discovery/marketplace.rs:94
"url" => Ok(Self::Url {
	url: take_required_string(&mut map, "url")?,
	sha: take_optional_string(&mut map, "sha")?,
}),
```

```rust
// crates/cc-plugins/src/installer/registry.rs:155
return vec![normalized_url];
```

```rust
// crates/cc-plugins/src/installer/registry.rs:273
for tarball_url in repository_archive_urls(url, revision) {
	match GitBasedInstaller
		.download_and_extract(&tarball_url, "", target_dir)
```

```rust
// crates/cc-plugins/src/installer/git.rs:137
for entry in archive.entries()? {
	let mut entry = entry?;
	let path = entry.path()?;
	let path_str = path.to_string_lossy();
```

```rust
// crates/cc-plugins/src/installer/git.rs:151
let target_path = target_dir.join(relative_path);
```

```rust
// crates/cc-plugins/src/installer/git.rs:159
entry.unpack(target_path)?;
```

Repo conventions:

- `aghub-cc-plugins` uses `anyhow::Result` and context-rich errors.
- Existing extraction tests live in `crates/cc-plugins/src/installer/git.rs` near `test_extract_tarball_from_repo_root`.
- Keep async network download behavior unchanged; this plan only changes local archive validation/extraction.

## Commands you will need

| Purpose | Command | Expected on success |
| ------- | ------- | ------------------- |
| Plugin extraction tests | `cargo test -p aghub-cc-plugins extract_tarball` | exit 0; new unsafe-entry tests pass |
| Plugin crate tests | `cargo test -p aghub-cc-plugins` | exit 0 |
| Format check | `cargo fmt --all -- --check` | exit 0 |
| Lint, if dependencies/types changed | `cargo clippy -p aghub-cc-plugins -- -D warnings` | exit 0, no warnings |

## Scope

**In scope**:

- `crates/cc-plugins/src/installer/git.rs`.
- Focused tests in the same file.
- `crates/cc-plugins/Cargo.toml` only if a dependency feature is required for safe extraction.

**Out of scope**:

- Changing marketplace source semantics.
- Rewriting plugin install/update lifecycle.
- Adding archive signature verification or checksum enforcement.
- Changing git clone behavior outside tarball extraction.

## Git workflow

- Branch: `advisor/005-secure-archive-extraction`.
- Commit message: `fix(plugins): validate archive extraction paths`.
- Do not push or open a PR unless instructed.

## Steps

### Step 1: Add safe relative-path validation

In `crates/cc-plugins/src/installer/git.rs`, add a helper such as:

```rust
fn safe_archive_relative_path(path: &Path) -> anyhow::Result<&Path>
```

or an owned `PathBuf` returning helper that:

- Rejects absolute paths.
- Rejects Windows prefixes.
- Rejects `..` parent components.
- Rejects empty paths after stripping the repository prefix/subdir.
- Normalizes only `.` and normal components.

Use `std::path::Component` rather than string-only checks.

**Verify**: Add unit tests for the helper with normal paths, `../escape`, `/absolute`, and Windows-prefix-like inputs where possible. Run `cargo test -p aghub-cc-plugins safe_archive_relative_path` → exit 0.

### Step 2: Reject unsafe tar entry types

Before unpacking each entry, inspect `entry.header().entry_type()` and reject or skip unsafe types:

- Allow regular files and directories.
- Reject symlinks and hard links unless the tar crate's containment-safe API can prove both link target and output path stay inside `target_dir`. The safer v1 is to reject both with a clear error.
- Reject device nodes, FIFOs, and other special entries.

Return an error that names the unsafe kind and entry path, but do not include any secret data.

**Verify**: Add tests with tar symlink/hard-link entries and expect extraction to fail without creating files outside the temp dir. Run `cargo test -p aghub-cc-plugins extract_tarball_rejects` → exit 0.

### Step 3: Use containment-safe extraction for accepted entries

Update the extraction loop:

1. Continue finding the common repository prefix and applying `subdir` filtering as today.
2. After stripping `extract_prefix`, convert the remaining path with the safe relative-path helper.
3. Create directories under `target_dir` only after validation.
4. Prefer `entry.unpack_in(target_dir)` if it supports the desired stripped relative path safely. If using `entry.unpack(target_path)`, first ensure:
   - `target_dir` exists and is canonicalized.
   - The target parent is created under `target_dir`.
   - The canonical parent remains under the canonical target root.
   - The target file does not traverse outside the root.
5. Do not follow symlinks during parent validation.

The final implementation should make it impossible for archive contents to write outside `target_dir` even when entry names contain traversal sequences.

**Verify**: `cargo test -p aghub-cc-plugins extract_tarball_from_repo_root -- --exact` → existing happy path still passes.

### Step 4: Add traversal regression tests

Add tests near existing extraction tests:

- `extract_tarball_rejects_parent_directory_escape` — tar contains an entry under the accepted prefix whose stripped path attempts to escape; extraction returns error and an outside sentinel file is not created.
- `extract_tarball_rejects_absolute_paths` — absolute entry rejected.
- `extract_tarball_rejects_symlink_entries` — symlink entry rejected.
- `extract_tarball_keeps_valid_subdir_extraction_working` — valid files under a requested subdir still extract.

Construct tarballs in memory like the existing `test_extract_tarball_from_repo_root` does.

**Verify**: `cargo test -p aghub-cc-plugins extract_tarball` → exit 0.

### Step 5: Check registry archive flow still uses the hardened extractor

Confirm `extract_repository_archive` still calls `GitBasedInstaller.download_and_extract`, and no other archive extraction path bypasses the hardened helper. Use ripgrep:

`rg -n "unpack\(|unpack_in|Archive::new|extract_tarball" crates/cc-plugins/src`

Expected result: every tar archive extraction path is either the hardened helper or a test.

**Verify**: `cargo test -p aghub-cc-plugins` → exit 0.

## Test plan

New tests in `crates/cc-plugins/src/installer/git.rs`:

- Safe relative path helper accepts normal paths and rejects traversal/absolute paths.
- Parent-directory escape tar entries are rejected.
- Absolute tar entries are rejected.
- Symlink and hard-link entries are rejected.
- Existing valid root/subdir extraction still works.

## Done criteria

- [ ] Archive extraction validates stripped relative paths with `Path::components`, not only string prefix checks.
- [ ] Regular files/directories cannot write outside `target_dir`.
- [ ] Symlink, hard-link, device, FIFO, and other special entries are rejected or proven safe by tests.
- [ ] Existing valid archive extraction tests still pass.
- [ ] `cargo test -p aghub-cc-plugins` exits 0.
- [ ] `cargo fmt --all -- --check` exits 0.
- [ ] `cargo clippy -p aghub-cc-plugins -- -D warnings` exits 0 if code/dependencies changed enough to warrant it.
- [ ] `plans/README.md` row 005 is updated to DONE by the executor.

## STOP conditions

Stop and report back if:

- The tar crate version does not expose a safe API and manual containment cannot be implemented without following symlinks.
- Existing plugin archives rely on symlinks/hard links and rejecting them would break a known supported source.
- The common-prefix/subdir stripping logic cannot be preserved while validating paths safely.
- Any verification command fails twice after reasonable fixes.

## Maintenance notes

This only protects tarball extraction. If future plugin sources add zip/npm archive extraction, they need equivalent containment tests. Reviewers should inspect both path validation and tar entry type handling, not just the happy-path extraction behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security validation during tarball extraction to prevent extraction of unsafe archive entries.
  * Ensures extracted files remain within the intended directory and rejects symlinks, absolute paths, and directory escape attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->