### PR TITLE
feat(desktop): add 'auto-check updates' setting

### DIFF
--- a/crates/desktop/src/App.tsx
+++ b/crates/desktop/src/App.tsx
@@ -10,6 +10,7 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useKeyBindings } from "rooks";
 import { Route, Router, Switch, useLocation } from "wouter";
+import { AutoUpdateChecker } from "./components/auto-update-checker";
 import { DeepLinkImportModal } from "./components/deep-link-import-modal";
 import { OnboardingController } from "./components/onboarding-controller";
 import { Redirect } from "./components/redirect";
@@ -176,6 +177,7 @@ function App() {
 						<NuqsAdapter>
 							<Router>
 								<OnboardingController />
+								<AutoUpdateChecker />
 								<Switch>
 									<Route path="/">
 										<DefaultSidebarRoute />

--- a/crates/desktop/src/components/auto-update-checker.tsx
+++ b/crates/desktop/src/components/auto-update-checker.tsx
@@ -1,68 +1,81 @@
 import { toast } from "@heroui/react";
-import { check } from "@tauri-apps/plugin-updater";
+import { useQuery } from "@tanstack/react-query";
+import { check, type Update } from "@tauri-apps/plugin-updater";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "wouter";
 import { getAutoCheckUpdates } from "../lib/store";
 
+const AUTO_UPDATE_CHECK_KEY = ["auto-update-check"] as const;
 const SESSION_STORAGE_KEY = "aghub-auto-update-check-session";
+
+interface AutoUpdateCheckResult {
+	update: Update | null;
+}
+
+async function runAutoUpdateCheck(): Promise<AutoUpdateCheckResult> {
+	if (typeof window !== "undefined") {
+		try {
+			if (window.sessionStorage.getItem(SESSION_STORAGE_KEY)) {
+				return { update: null };
+			}
+			window.sessionStorage.setItem(SESSION_STORAGE_KEY, "1");
+		} catch {
+			// sessionStorage may be unavailable; fall through and let
+			// the preference gate handle dedupe within this session.
+		}
+	}
+
+	const enabled = await getAutoCheckUpdates();
+	if (!enabled) {
+		return { update: null };
+	}
+
+	const update = await check();
+	return { update };
+}
 
 /**
  * Runs a single background `check()` on app startup, gated by the
  * `autoCheckUpdates` preference. If an update is found, surfaces a
- * toast that takes the user to the Settings → Application panel.
+ * toast whose action takes the user to the Settings → Application
+ * panel where they can install it.
  *
- * Silently swallows errors (network failures etc.) — the user can
- * always trigger a manual check from Settings.
+ * The fetch is owned by React Query (`useQuery`); the toast is
+ * surfaced as a side effect of the fetched data, which is the
+ * documented pattern for this codebase (see AGENTS.md: "use
+ * `useQuery` from React Query or custom hooks instead" of
+ * `useEffect` for data fetching).
+ *
+ * Errors are swallowed silently — the user can always trigger a
+ * manual check from Settings.
  */
 export function AutoUpdateChecker() {
 	const { t } = useTranslation();
-	const ranForSessionRef = useRef(false);
+	const [, setLocation] = useLocation();
+	const surfacedRef = useRef(false);
+
+	const { data } = useQuery<AutoUpdateCheckResult>({
+		queryKey: AUTO_UPDATE_CHECK_KEY,
+		queryFn: runAutoUpdateCheck,
+		staleTime: Infinity,
+		gcTime: Infinity,
+		retry: false,
+	});
 
 	useEffect(() => {
-		if (ranForSessionRef.current) return;
-		ranForSessionRef.current = true;
+		if (!data?.update || surfacedRef.current) return;
+		surfacedRef.current = true;
 
-		// Ensure at most one auto-check per app session, even if the
-		// component is re-mounted (HMR, fast refresh, etc.).
-		if (typeof window !== "undefined") {
-			try {
-				if (window.sessionStorage.getItem(SESSION_STORAGE_KEY)) {
-					return;
-				}
-				window.sessionStorage.setItem(SESSION_STORAGE_KEY, "1");
-			} catch {
-				// sessionStorage may be unavailable; fall through and
-				// rely on the in-memory ref to dedupe within this mount.
-			}
-		}
-
-		let cancelled = false;
-
-		const run = async () => {
-			try {
-				const enabled = await getAutoCheckUpdates();
-				if (!enabled || cancelled) return;
-
-				const update = await check();
-				if (!update || cancelled) return;
-
-				toast.success(
-					t("updateAvailable", { version: update.version }),
-					{
-						description: t("clickToCheckUpdates"),
-					},
-				);
-			} catch (error) {
-				console.warn("Automatic update check failed:", error);
-			}
-		};
-
-		void run();
-
-		return () => {
-			cancelled = true;
-		};
-	}, [t]);
+		toast.success(t("updateAvailable", { version: data.update.version }), {
+			description: t("clickToCheckUpdates"),
+			actionProps: {
+				onPress: () => setLocation("/settings"),
+				variant: "tertiary",
+				children: t("openSettings"),
+			},
+		});
+	}, [data, setLocation, t]);
 
 	return null;
 }

--- a/crates/desktop/src/components/auto-update-checker.tsx
+++ b/crates/desktop/src/components/auto-update-checker.tsx
@@ -1,0 +1,68 @@
+import { toast } from "@heroui/react";
+import { check } from "@tauri-apps/plugin-updater";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { getAutoCheckUpdates } from "../lib/store";
+
+const SESSION_STORAGE_KEY = "aghub-auto-update-check-session";
+
+/**
+ * Runs a single background `check()` on app startup, gated by the
+ * `autoCheckUpdates` preference. If an update is found, surfaces a
+ * toast that takes the user to the Settings → Application panel.
+ *
+ * Silently swallows errors (network failures etc.) — the user can
+ * always trigger a manual check from Settings.
+ */
+export function AutoUpdateChecker() {
+	const { t } = useTranslation();
+	const ranForSessionRef = useRef(false);
+
+	useEffect(() => {
+		if (ranForSessionRef.current) return;
+		ranForSessionRef.current = true;
+
+		// Ensure at most one auto-check per app session, even if the
+		// component is re-mounted (HMR, fast refresh, etc.).
+		if (typeof window !== "undefined") {
+			try {
+				if (window.sessionStorage.getItem(SESSION_STORAGE_KEY)) {
+					return;
+				}
+				window.sessionStorage.setItem(SESSION_STORAGE_KEY, "1");
+			} catch {
+				// sessionStorage may be unavailable; fall through and
+				// rely on the in-memory ref to dedupe within this mount.
+			}
+		}
+
+		let cancelled = false;
+
+		const run = async () => {
+			try {
+				const enabled = await getAutoCheckUpdates();
+				if (!enabled || cancelled) return;
+
+				const update = await check();
+				if (!update || cancelled) return;
+
+				toast.success(
+					t("updateAvailable", { version: update.version }),
+					{
+						description: t("clickToCheckUpdates"),
+					},
+				);
+			} catch (error) {
+				console.warn("Automatic update check failed:", error);
+			}
+		};
+
+		void run();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [t]);
+
+	return null;
+}

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -412,6 +412,13 @@ export default {
 	updateInstalledSuccess: "Update installed successfully",
 	restartToUpdate: "Restart to Update",
 	restartNow: "Restart Now",
+	settingsAutoCheckUpdatesHeading: "Check for updates automatically",
+	settingsAutoCheckUpdatesDescription:
+		"Let aghub check for new versions in the background when the app starts. You can still trigger a manual check at any time.",
+	settingsAutoCheckUpdatesToggleLabel: "Check for updates automatically",
+	settingsAutoCheckUpdatesEnabled: "Automatic update checks enabled",
+	settingsAutoCheckUpdatesDisabled: "Automatic update checks disabled",
+	settingsAutoCheckUpdatesError: "Failed to update automatic update checks",
 	onboardingDescription:
 		"Replay the welcome screen or either guided tour any time.",
 

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -419,6 +419,7 @@ export default {
 	settingsAutoCheckUpdatesEnabled: "Automatic update checks enabled",
 	settingsAutoCheckUpdatesDisabled: "Automatic update checks disabled",
 	settingsAutoCheckUpdatesError: "Failed to update automatic update checks",
+	openSettings: "Open Settings",
 	onboardingDescription:
 		"Replay the welcome screen or either guided tour any time.",
 

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -395,6 +395,13 @@ export default {
 	updateInstalledSuccess: "更新已安装成功",
 	restartToUpdate: "重启更新",
 	restartNow: "立即重启",
+	settingsAutoCheckUpdatesHeading: "自动检查更新",
+	settingsAutoCheckUpdatesDescription:
+		"允许 aghub 在应用启动时在后台检查新版本。你仍然可以随时手动检查更新。",
+	settingsAutoCheckUpdatesToggleLabel: "自动检查更新",
+	settingsAutoCheckUpdatesEnabled: "已开启自动检查更新",
+	settingsAutoCheckUpdatesDisabled: "已关闭自动检查更新",
+	settingsAutoCheckUpdatesError: "更新自动检查更新设置失败",
 	onboardingDescription: "随时重新打开欢迎页或任一引导流程。",
 
 	// Onboarding — Wizard

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -402,6 +402,7 @@ export default {
 	settingsAutoCheckUpdatesEnabled: "已开启自动检查更新",
 	settingsAutoCheckUpdatesDisabled: "已关闭自动检查更新",
 	settingsAutoCheckUpdatesError: "更新自动检查更新设置失败",
+	openSettings: "打开设置",
 	onboardingDescription: "随时重新打开欢迎页或任一引导流程。",
 
 	// Onboarding — Wizard

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -394,6 +394,13 @@ export default {
 	updateInstalledSuccess: "更新已安裝成功",
 	restartToUpdate: "重新啟動以更新",
 	restartNow: "立即重新啟動",
+	settingsAutoCheckUpdatesHeading: "自動檢查更新",
+	settingsAutoCheckUpdatesDescription:
+		"允許 aghub 在應用啟動時於背景檢查新版本。你仍可隨時手動檢查更新。",
+	settingsAutoCheckUpdatesToggleLabel: "自動檢查更新",
+	settingsAutoCheckUpdatesEnabled: "已開啟自動檢查更新",
+	settingsAutoCheckUpdatesDisabled: "已關閉自動檢查更新",
+	settingsAutoCheckUpdatesError: "更新自動檢查更新設定失敗",
 	onboardingDescription: "隨時重新開啟歡迎頁或任一導覽流程。",
 
 	// Onboarding — Wizard

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -401,6 +401,7 @@ export default {
 	settingsAutoCheckUpdatesEnabled: "已開啟自動檢查更新",
 	settingsAutoCheckUpdatesDisabled: "已關閉自動檢查更新",
 	settingsAutoCheckUpdatesError: "更新自動檢查更新設定失敗",
+	openSettings: "開啟設定",
 	onboardingDescription: "隨時重新開啟歡迎頁或任一導覽流程。",
 
 	// Onboarding — Wizard

--- a/crates/desktop/src/lib/store.ts
+++ b/crates/desktop/src/lib/store.ts
@@ -2,8 +2,10 @@ export { disableAgent, enableAgent, getDisabledAgents } from "./store/agents";
 export {
 	type AnalyticsConsent,
 	getAnalyticsConsent,
+	getAutoCheckUpdates,
 	getConsentAcked,
 	setAnalyticsConsent,
+	setAutoCheckUpdates,
 	setConsentAcked,
 	getStore,
 	initStore,

--- a/crates/desktop/src/lib/store/index.ts
+++ b/crates/desktop/src/lib/store/index.ts
@@ -61,3 +61,25 @@ export async function setConsentAcked(value: boolean): Promise<void> {
 	await s.set(ANALYTICS_CONSENT_ACK_KEY, value);
 	await s.save();
 }
+
+const AUTO_CHECK_UPDATES_KEY = "autoCheckUpdates";
+
+/**
+ * Default: enabled. The app will check for updates on startup unless
+ * the user has explicitly opted out via Settings → Application.
+ */
+const DEFAULT_AUTO_CHECK_UPDATES = true;
+
+export async function getAutoCheckUpdates(): Promise<boolean> {
+	const s = await getStore();
+	const value = await s.get<boolean>(AUTO_CHECK_UPDATES_KEY);
+	if (typeof value === "boolean") return value;
+	return DEFAULT_AUTO_CHECK_UPDATES;
+}
+
+export async function setAutoCheckUpdates(value: boolean): Promise<boolean> {
+	const s = await getStore();
+	await s.set(AUTO_CHECK_UPDATES_KEY, value);
+	await s.save();
+	return value;
+}

--- a/crates/desktop/src/lib/store/migrations/index.ts
+++ b/crates/desktop/src/lib/store/migrations/index.ts
@@ -6,6 +6,7 @@ import { migrateV2ToV3 } from "./v2-to-v3";
 import { migrateV3ToV4 } from "./v3-to-v4";
 import { migrateV4ToV5 } from "./v4-to-v5";
 import { migrateV5ToV6 } from "./v5-to-v6";
+import { migrateV6ToV7 } from "./v6-to-v7";
 
 export async function migrate(store: Store): Promise<void> {
 	const version = (await store.get<number>("version")) ?? 0;
@@ -34,6 +35,10 @@ export async function migrate(store: Store): Promise<void> {
 
 	if (version < 6) {
 		await migrateV5ToV6(store);
+	}
+
+	if (version < 7) {
+		await migrateV6ToV7(store);
 	}
 
 	await store.set("version", CURRENT_VERSION);

--- a/crates/desktop/src/lib/store/migrations/v6-to-v7.ts
+++ b/crates/desktop/src/lib/store/migrations/v6-to-v7.ts
@@ -1,0 +1,5 @@
+import type { Store } from "@tauri-apps/plugin-store";
+
+export async function migrateV6ToV7(store: Store): Promise<void> {
+	await store.set("autoCheckUpdates", true);
+}

--- a/crates/desktop/src/lib/store/types.ts
+++ b/crates/desktop/src/lib/store/types.ts
@@ -34,7 +34,7 @@ export interface SidebarItemPreference {
 	visible: boolean;
 }
 
-export const CURRENT_VERSION = 6;
+export const CURRENT_VERSION = 7;
 
 export const DEFAULT_ONBOARDING_PROGRESS: OnboardingProgress = {
 	hasSeenWelcome: false,

--- a/crates/desktop/src/pages/settings/application-panel.tsx
+++ b/crates/desktop/src/pages/settings/application-panel.tsx
@@ -13,7 +13,12 @@ import { useTranslation } from "react-i18next";
 import { applyAnalyticsConsent } from "../../lib/analytics";
 import { dispatchOnboardingCommand } from "../../lib/onboarding";
 import { isWindows } from "../../lib/platform";
-import { getAnalyticsConsent, setAnalyticsConsent } from "../../lib/store";
+import {
+	getAnalyticsConsent,
+	getAutoCheckUpdates,
+	setAnalyticsConsent,
+	setAutoCheckUpdates,
+} from "../../lib/store";
 
 export default function ApplicationPanel() {
 	const { t } = useTranslation();
@@ -40,6 +45,12 @@ export default function ApplicationPanel() {
 			queryKey: ["windows-autostart"],
 			queryFn: isAutostartEnabled,
 			enabled: isWindowsOS,
+		});
+
+	const { data: autoCheckUpdates = true, isPending: isAutoCheckLoading } =
+		useQuery({
+			queryKey: ["auto-check-updates"],
+			queryFn: getAutoCheckUpdates,
 		});
 
 	const analyticsMutation = useMutation({
@@ -86,6 +97,30 @@ export default function ApplicationPanel() {
 				error instanceof Error
 					? error.message
 					: t("settingsAutostartError"),
+			);
+		},
+	});
+
+	const autoCheckUpdatesMutation = useMutation({
+		mutationFn: async (enabled: boolean) => {
+			await setAutoCheckUpdates(enabled);
+			return enabled;
+		},
+		onSuccess: (enabled) => {
+			queryClient.invalidateQueries({
+				queryKey: ["auto-check-updates"],
+			});
+			toast.success(
+				enabled
+					? t("settingsAutoCheckUpdatesEnabled")
+					: t("settingsAutoCheckUpdatesDisabled"),
+			);
+		},
+		onError: (error) => {
+			toast.danger(
+				error instanceof Error
+					? error.message
+					: t("settingsAutoCheckUpdatesError"),
 			);
 		},
 	});
@@ -252,6 +287,34 @@ export default function ApplicationPanel() {
 								</Button>
 							)}
 						</div>
+					</div>
+
+					<div className="flex items-center justify-between gap-4">
+						<div className="space-y-0.5">
+							<span className="text-sm font-medium text-(--foreground)">
+								{t("settingsAutoCheckUpdatesHeading")}
+							</span>
+							<span className="block text-xs text-muted">
+								{t("settingsAutoCheckUpdatesDescription")}
+							</span>
+						</div>
+						<Switch
+							isSelected={autoCheckUpdates}
+							onChange={(checked) =>
+								autoCheckUpdatesMutation.mutate(checked)
+							}
+							isDisabled={
+								isAutoCheckLoading ||
+								autoCheckUpdatesMutation.isPending
+							}
+							aria-label={t(
+								"settingsAutoCheckUpdatesToggleLabel",
+							)}
+						>
+							<Switch.Control>
+								<Switch.Thumb />
+							</Switch.Control>
+						</Switch>
 					</div>
 
 					<div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
Adds a Switch in Settings → Application that lets the user opt out of the startup update check.

- New `autoCheckUpdates` store key (default `true`) with `getAutoCheckUpdates` / `setAutoCheckUpdates` helpers, plus a v6 → v7 migration that seeds the default for existing installs.
- New `AutoUpdateChecker` component invokes `@tauri-apps/plugin-updater`'s `check()` once per app session when the preference is enabled, surfacing a toast if a new version is found. Errors (network failures etc.) are logged and silently ignored.
- The existing manual "Check for Updates" / "Check Again" button is unchanged.
- i18n strings added to `en`, `zh-Hans`, `zh-Hant`.

Closes KIT-37.

Verified locally:
- `bun run typecheck` — clean
- `bun run lint` — no new issues (2 pre-existing warnings in `claude-panel.tsx` / `codex-panel.tsx` are unrelated)
- `bun run format:check` — clean
- `bun run build` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic update checking on app startup; when an update is detected, a toast notification is shown and the user can navigate to Settings.
  * Added a new Settings option to enable/disable automatic update checks (default enabled) and persist the choice across sessions.
  * Added localized (English and Chinese variants) text for the new automatic update setting, including status and error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->