### PR TITLE
fix(desktop): align react-dom with react

### DIFF
--- a/crates/desktop/bun.lock
+++ b/crates/desktop/bun.lock
@@ -39,7 +39,7 @@
         "posthog-js": "^1.378.1",
         "react": "19.2.7",
         "react-aria-components": "^1.16.0",
-        "react-dom": "19.2.6",
+        "react-dom": "19.2.7",
         "react-grab": "^0.1.32",
         "react-hook-form": "^7.76.1",
         "react-i18next": "^17.0.0",
@@ -1326,7 +1326,7 @@
 
     "react-aria-components": ["react-aria-components@1.16.0", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@internationalized/string": "^3.2.7", "@react-aria/autocomplete": "3.0.0-rc.6", "@react-aria/collections": "^3.0.3", "@react-aria/dnd": "^3.11.6", "@react-aria/focus": "^3.21.5", "@react-aria/interactions": "^3.27.1", "@react-aria/live-announcer": "^3.4.4", "@react-aria/overlays": "^3.31.2", "@react-aria/ssr": "^3.9.10", "@react-aria/textfield": "^3.18.5", "@react-aria/toolbar": "3.0.0-beta.24", "@react-aria/utils": "^3.33.1", "@react-aria/virtualizer": "^4.1.13", "@react-stately/autocomplete": "3.0.0-beta.4", "@react-stately/layout": "^4.6.0", "@react-stately/selection": "^3.20.9", "@react-stately/table": "^3.15.4", "@react-stately/utils": "^3.11.0", "@react-stately/virtualizer": "^4.4.6", "@react-types/form": "^3.7.18", "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1", "@react-types/table": "^3.13.6", "@swc/helpers": "^0.5.0", "client-only": "^0.0.1", "react-aria": "^3.47.0", "react-stately": "^3.45.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-MjHbTLpMFzzD2Tv5KbeXoZwPczuUWZcRavVvQQlNHRtXHH38D+sToMEYpNeir7Wh3K/XWtzeX3EujfJW6QNkrw=="],
 
-    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "react-grab": ["react-grab@0.1.32", "", { "dependencies": { "@react-grab/cli": "0.1.32", "bippy": "^0.5.39" }, "peerDependencies": { "react": ">=17.0.0" }, "optionalPeers": ["react"], "bin": { "react-grab": "bin/cli.js" } }, "sha512-ODZkzu4zjwX/5a1VxTdIkagPD6uPnp8IkSN2v5FDgFMZkH5r/YEMq43hIsdpHV5/R2ymqS9zLxp4H7SNSRx5ng=="],
 

--- a/crates/desktop/package.json
+++ b/crates/desktop/package.json
@@ -49,7 +49,7 @@
 		"posthog-js": "^1.378.1",
 		"react": "19.2.7",
 		"react-aria-components": "^1.16.0",
-		"react-dom": "19.2.6",
+		"react-dom": "19.2.7",
 		"react-grab": "^0.1.32",
 		"react-hook-form": "^7.76.1",
 		"react-i18next": "^17.0.0",


### PR DESCRIPTION
## Summary
- Align react-dom with the pinned React version so the production desktop bundle no longer aborts during React startup.
- Regenerate the Bun lockfile for react-dom 19.2.7.

## Verification
- bun run build
- Mocked production-preview startup reproduced React minified error #527 before the fix and no pageerror after the fix; startup reached store migration and start_server.
- bun run tauri build --target aarch64-apple-darwin produced the macOS app, DMG, and updater tarball, then failed only because local TAURI_SIGNING_PRIVATE_KEY is not configured.
- Launched the generated macOS app; logs showed frontend Tauri log attachment and Desktop API server startup on 127.0.0.1:55901, and store.json migrated to version 7.