### PR TITLE
KIT-43: Centralize dependency versions with catalogs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ thiserror = "2.0"
 dirs = "6.0"
 libc = "0.2"
 ts-rs = "12.0.1"
+which = "8"
+log = "0.4.31"
 
 # CLI dependencies
 clap = { version = "4.5", features = [ "derive" ] }
@@ -45,6 +47,16 @@ colored = "3.0"
 # HTTP dependencies
 reqwest = { version = "0.13", features = [ "json" ] }
 url = "2.5"
+
+# Async and shared platform dependencies
+tokio = "1"
+keyring = { version = "3", features = [
+	"apple-native",
+	"windows-native",
+	"linux-native",
+] }
+uuid = { version = "1", features = [ "v4" ] }
+tauri = "2"
 
 # Testing dependencies
 tempfile = "3.10"
@@ -60,6 +72,9 @@ toml_edit = "0.25"
 
 # Interactive CLI
 inquire = "0.9"
+
+# Date/time
+chrono = { version = "0.4", features = [ "serde" ] }
 
 # Git hooks
 cargo-husky = { version = "1", default-features = false, features = [

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -13,7 +13,7 @@ toml = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }
 libc = { workspace = true }
-which = "8"
+which = { workspace = true }
 aghub-markdown = { path = "../markdown" }
 
 [dev-dependencies]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -24,21 +24,17 @@ skill = { path = "../skill" }
 skills-sh = { path = "../skills-sh" }
 rocket = { version = "0.5", features = [ "json" ] }
 rocket_cors = "0.6.0"
-tokio = { version = "1", features = [ "rt-multi-thread", "macros", "process" ] }
+tokio = { workspace = true, features = [ "rt-multi-thread", "macros", "process" ] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }
 ts-rs = { workspace = true }
-which = "8"
+which = { workspace = true }
 open = "5"
-tempfile = "3"
-keyring = { version = "3", features = [
-	"apple-native",
-	"windows-native",
-	"linux-native",
-] }
-uuid = { version = "1", features = [ "v4" ] }
-log = "0.4.31"
-reqwest = { version = "0.13", features = [ "json" ] }
+tempfile = { workspace = true }
+keyring = { workspace = true }
+uuid = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
 url = { workspace = true }

--- a/crates/cc-plugins/Cargo.toml
+++ b/crates/cc-plugins/Cargo.toml
@@ -14,7 +14,7 @@ reqwest = { workspace = true }
 aghub-git = { path = "../git" }
 
 # Async runtime
-tokio = { version = "1", features = [
+tokio = { workspace = true, features = [
 	"fs",
 	"process",
 	"time",
@@ -27,7 +27,7 @@ flate2 = "1.0"
 tar = "0.4"
 
 # Date/time
-chrono = { version = "0.4", features = [ "serde" ] }
+chrono = { workspace = true }
 
 # Hash for URL-based sources
 sha2 = "0.11"
@@ -37,8 +37,8 @@ semver = "1.0.28"
 thiserror = { workspace = true }
 
 # Logging
-log = "0.4"
+log = { workspace = true }
 tempfile = { workspace = true }
 
 # CLI binary detection
-which = "8"
+which = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ tabled = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1", features = [ "rt", "macros" ] }
+tokio = { workspace = true, features = [ "rt", "macros" ] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,8 +15,8 @@ dirs = { workspace = true }
 toml = { workspace = true }
 tempfile = { workspace = true }
 skill = { path = "../skill" }
-which = "8"
-log = "0.4.31"
+which = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
 aghub-agents = { path = "../agents" }

--- a/crates/desktop/bun.lock
+++ b/crates/desktop/bun.lock
@@ -37,9 +37,9 @@
         "pathe": "^2.0.3",
         "pinyin-pro": "^3.28.1",
         "posthog-js": "^1.378.1",
-        "react": "19.2.7",
+        "react": "catalog:",
         "react-aria-components": "^1.16.0",
-        "react-dom": "19.2.7",
+        "react-dom": "catalog:",
         "react-grab": "^0.1.32",
         "react-hook-form": "^7.79.0",
         "react-i18next": "^17.0.0",
@@ -72,6 +72,10 @@
         "vite": "^8.0.16",
       },
     },
+  },
+  "catalog": {
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
   },
   "packages": {
     "@antfu/eslint-config": ["@antfu/eslint-config@8.1.1", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@clack/prompts": "^1.2.0", "@e18e/eslint-plugin": "^0.3.0", "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1", "@eslint/markdown": "^8.0.1", "@stylistic/eslint-plugin": "^5.10.0", "@typescript-eslint/eslint-plugin": "^8.58.1", "@typescript-eslint/parser": "^8.58.1", "@vitest/eslint-plugin": "^1.6.14", "ansis": "^4.2.0", "cac": "^7.0.0", "eslint-config-flat-gitignore": "^2.3.0", "eslint-flat-config-utils": "^3.1.0", "eslint-merge-processors": "^2.0.0", "eslint-plugin-antfu": "^3.2.2", "eslint-plugin-command": "^3.5.2", "eslint-plugin-import-lite": "^0.6.0", "eslint-plugin-jsdoc": "^62.9.0", "eslint-plugin-jsonc": "^3.1.2", "eslint-plugin-n": "^17.24.0", "eslint-plugin-no-only-tests": "^3.3.0", "eslint-plugin-perfectionist": "^5.8.0", "eslint-plugin-pnpm": "^1.6.0", "eslint-plugin-regexp": "^3.1.0", "eslint-plugin-toml": "^1.3.1", "eslint-plugin-unicorn": "^64.0.0", "eslint-plugin-unused-imports": "^4.4.1", "eslint-plugin-vue": "^10.8.0", "eslint-plugin-yml": "^3.3.1", "eslint-processor-vue-blocks": "^2.0.0", "globals": "^17.4.0", "local-pkg": "^1.1.2", "parse-gitignore": "^2.0.0", "toml-eslint-parser": "^1.0.3", "vue-eslint-parser": "^10.4.0", "yaml-eslint-parser": "^2.0.0" }, "peerDependencies": { "@angular-eslint/eslint-plugin": "^21.1.0", "@angular-eslint/eslint-plugin-template": "^21.1.0", "@angular-eslint/template-parser": "^21.1.0", "@eslint-react/eslint-plugin": "^3.0.0", "@next/eslint-plugin-next": ">=15.0.0", "@prettier/plugin-xml": "^3.4.1", "@unocss/eslint-plugin": ">=0.50.0", "astro-eslint-parser": "^1.0.2", "eslint": "^9.10.0 || ^10.0.0", "eslint-plugin-astro": "^1.2.0", "eslint-plugin-format": ">=0.1.0", "eslint-plugin-jsx-a11y": ">=6.10.2", "eslint-plugin-react-refresh": "^0.5.0", "eslint-plugin-solid": "^0.14.3", "eslint-plugin-svelte": ">=2.35.1", "eslint-plugin-vuejs-accessibility": "^2.4.1", "prettier-plugin-astro": "^0.14.0", "prettier-plugin-slidev": "^1.0.5", "svelte-eslint-parser": ">=0.37.0" }, "optionalPeers": ["@angular-eslint/eslint-plugin", "@angular-eslint/eslint-plugin-template", "@angular-eslint/template-parser", "@eslint-react/eslint-plugin", "@next/eslint-plugin-next", "@prettier/plugin-xml", "@unocss/eslint-plugin", "astro-eslint-parser", "eslint-plugin-astro", "eslint-plugin-format", "eslint-plugin-jsx-a11y", "eslint-plugin-react-refresh", "eslint-plugin-solid", "eslint-plugin-svelte", "eslint-plugin-vuejs-accessibility", "prettier-plugin-astro", "prettier-plugin-slidev", "svelte-eslint-parser"], "bin": { "eslint-config": "bin/index.mjs" } }, "sha512-y5/eAKlJUbQpeES2Pnb0i/VgbmqQ+srHJJNqbTKEBsxdLy3h1BqdS00zDpE+YeP71EWmlYJSTUhcJg4n4yMeAQ=="],

--- a/crates/desktop/package.json
+++ b/crates/desktop/package.json
@@ -2,6 +2,12 @@
 	"name": "aghub",
 	"type": "module",
 	"private": true,
+	"workspaces": {
+		"catalog": {
+			"react": "19.2.7",
+			"react-dom": "19.2.7"
+		}
+	},
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc && vite build",
@@ -47,9 +53,9 @@
 		"pathe": "^2.0.3",
 		"pinyin-pro": "^3.28.1",
 		"posthog-js": "^1.378.1",
-		"react": "19.2.7",
+		"react": "catalog:",
 		"react-aria-components": "^1.16.0",
-		"react-dom": "19.2.7",
+		"react-dom": "catalog:",
 		"react-grab": "^0.1.32",
 		"react-hook-form": "^7.79.0",
 		"react-i18next": "^17.0.0",

--- a/crates/desktop/src-tauri/Cargo.toml
+++ b/crates/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ dotenvy = "0.15.7"
 tauri-build = { version = "2", features = [  ] }
 
 [dependencies]
-tauri = { version = "2", features = [ "tray-icon" ] }
+tauri = { workspace = true, features = [ "tray-icon" ] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-deep-link = "2.4.7"
@@ -28,18 +28,18 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-log = { version = "2.8.0", features = [ "colored" ] }
-serde = { version = "1", features = [ "derive" ] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 aghub-api = { path = "../../api" }
-tokio = { version = "1", features = [ "rt" ] }
+tokio = { workspace = true, features = [ "rt" ] }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
-log = "0.4.31"
-time = { version = "0.3", features = ["formatting", "local-offset"] }
-zip = { version = "8", default-features = false, features = ["deflate"] }
+log = { workspace = true }
+time = { version = "0.3", features = [ "formatting", "local-offset" ] }
+zip = { version = "8", default-features = false, features = [ "deflate" ] }
 posthog-rs = "0.7.0"
-uuid = { version = "1", features = [ "v4" ] }
+uuid = { workspace = true }
 tauri-plugin-autostart = "2.5.1"
 sys-locale = "0.3.2"
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -14,15 +14,11 @@ toml_edit = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }
 url = { workspace = true }
-keyring = { version = "3", features = [
-	"apple-native",
-	"windows-native",
-	"linux-native",
-] }
-uuid = { version = "1", features = [ "v4" ] }
+keyring = { workspace = true }
+uuid = { workspace = true }
 sqlx = { version = "0.9", features = [ "sqlite", "runtime-tokio", "migrate" ] }
-tokio = { version = "1", features = [ "rt", "rt-multi-thread" ] }
-tauri = { version = "2", optional = true }
+tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
+tauri = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/skill/Cargo.toml
+++ b/crates/skill/Cargo.toml
@@ -16,7 +16,7 @@ zip = "8.0"
 tempfile = { workspace = true }
 skills-ref = { git = "https://github.com/AkaraChen/skills-ref" }
 walkdir = "2.5"
-chrono = { version = "0.4", features = [ "serde" ] }
+chrono = { workspace = true }
 dirs = { workspace = true }
 ignore = "0.4"
 

--- a/crates/skills-sh/Cargo.toml
+++ b/crates/skills-sh/Cargo.toml
@@ -14,5 +14,5 @@ reqwest = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = [ "rt-multi-thread", "macros" ] }
+tokio = { workspace = true, features = [ "rt-multi-thread", "macros" ] }
 tokio-test = "0.4"


### PR DESCRIPTION
Closes KIT-43

Summary:
- Added Bun catalogs for root tooling and the desktop package, with package manifests consuming versions through catalog:.
- Expanded Cargo workspace dependencies and switched member crates to inherit shared versions.
- Preserved the direct zip dependency pins where Cargo default-feature inheritance would change behavior.

Checks:
- bun install --frozen-lockfile
- cd crates/desktop && bun install --frozen-lockfile
- bun run format:check
- cd crates/desktop && bun run typecheck
- cargo metadata --no-deps --format-version=1
- cargo check --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized and centralized dependency management across Rust and JavaScript components using workspace-based version catalogs to improve consistency and simplify future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->