### PR TITLE
KIT-48: copy skills.sh search result links

### DIFF
--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -772,6 +772,10 @@ export default {
 	searchToFindSkills: "Search to find skills from skills.sh",
 	poweredByVercel: "Powered by Vercel",
 	dataFromSkillsSh: "Data from skills.sh",
+	copySkillsShLink: "Copy skills.sh link",
+	copySkillsShLinkHint: "Click to copy this skills.sh URL.",
+	skillsShLinkCopied: "skills.sh link copied",
+	skillsShLinkCopyFailed: "Failed to copy skills.sh link",
 
 	// MCP Detail
 	connection: "Connection",

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -773,7 +773,6 @@ export default {
 	poweredByVercel: "Powered by Vercel",
 	dataFromSkillsSh: "Data from skills.sh",
 	copySkillsShLink: "Copy skills.sh link",
-	copySkillsShLinkHint: "Click to copy this skills.sh URL.",
 	skillsShLinkCopied: "skills.sh link copied",
 	skillsShLinkCopyFailed: "Failed to copy skills.sh link",
 

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -764,7 +764,6 @@ export default {
 	poweredByVercel: "由 Vercel 提供支持",
 	dataFromSkillsSh: "数据来自 skills.sh",
 	copySkillsShLink: "复制 skills.sh 链接",
-	copySkillsShLinkHint: "点击可复制这个 skills.sh 地址。",
 	skillsShLinkCopied: "skills.sh 链接已复制",
 	skillsShLinkCopyFailed: "复制 skills.sh 链接失败",
 

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -763,6 +763,10 @@ export default {
 	searchToFindSkills: "搜索以从 skills.sh 查找技能",
 	poweredByVercel: "由 Vercel 提供支持",
 	dataFromSkillsSh: "数据来自 skills.sh",
+	copySkillsShLink: "复制 skills.sh 链接",
+	copySkillsShLinkHint: "点击可复制这个 skills.sh 地址。",
+	skillsShLinkCopied: "skills.sh 链接已复制",
+	skillsShLinkCopyFailed: "复制 skills.sh 链接失败",
 
 	// Projects
 	addProject: "添加项目",

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -762,7 +762,6 @@ export default {
 	poweredByVercel: "由 Vercel 提供支援",
 	dataFromSkillsSh: "資料來自 skills.sh",
 	copySkillsShLink: "複製 skills.sh 連結",
-	copySkillsShLinkHint: "點擊可複製這個 skills.sh 地址。",
 	skillsShLinkCopied: "skills.sh 連結已複製",
 	skillsShLinkCopyFailed: "複製 skills.sh 連結失敗",
 

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -761,6 +761,10 @@ export default {
 	searchToFindSkills: "搜尋以從 skills.sh 尋找技能",
 	poweredByVercel: "由 Vercel 提供支援",
 	dataFromSkillsSh: "資料來自 skills.sh",
+	copySkillsShLink: "複製 skills.sh 連結",
+	copySkillsShLinkHint: "點擊可複製這個 skills.sh 地址。",
+	skillsShLinkCopied: "skills.sh 連結已複製",
+	skillsShLinkCopyFailed: "複製 skills.sh 連結失敗",
 
 	// Projects
 	addProject: "新增專案",

--- a/crates/desktop/src/pages/skills-sh/search.tsx
+++ b/crates/desktop/src/pages/skills-sh/search.tsx
@@ -49,8 +49,21 @@ const tableComponents: TableComponents<MarketSkill> = {
 
 function buildSkillsShUrl(skill: MarketSkill) {
 	const sourceParts = skill.source.split("/").filter(Boolean);
-	const pathParts =
-		sourceParts[0] === "github" ? sourceParts.slice(1) : sourceParts;
+	const pathParts = (() => {
+		if (sourceParts.length === 0) {
+			return [];
+		}
+
+		if (sourceParts[0] === "github") {
+			return sourceParts.slice(1);
+		}
+
+		if (sourceParts[0] === "site") {
+			return sourceParts;
+		}
+
+		return ["site", ...sourceParts];
+	})();
 	const skillSegment = skill.slug || skill.name;
 	const urlSegments = [...pathParts, skillSegment]
 		.filter(Boolean)
@@ -126,11 +139,7 @@ export default function SkillsSearchPage() {
 				toast.success(t("skillsShLinkCopied"));
 			} catch (error) {
 				console.error("Failed to copy skills.sh URL:", error);
-				toast.danger(
-					error instanceof Error
-						? error.message
-						: t("skillsShLinkCopyFailed"),
-				);
+				toast.danger(t("skillsShLinkCopyFailed"));
 			}
 		},
 		[t],

--- a/crates/desktop/src/pages/skills-sh/search.tsx
+++ b/crates/desktop/src/pages/skills-sh/search.tsx
@@ -1,6 +1,7 @@
 import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
-import { Button, Spinner } from "@heroui/react";
+import { Button, Spinner, Tooltip, toast } from "@heroui/react";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useQueryState } from "nuqs";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -23,6 +24,7 @@ import { useSkillInstall } from "./hooks/use-skill-install";
 const BATCH_SIZE = 20;
 const FETCH_SIZE = 100;
 const ROW_HEIGHT = 48;
+const SKILLS_SH_BASE_URL = "https://www.skills.sh";
 
 const tableComponents: TableComponents<MarketSkill> = {
 	Table: ({ style, ...props }) => (
@@ -44,6 +46,18 @@ const tableComponents: TableComponents<MarketSkill> = {
 		/>
 	),
 };
+
+function buildSkillsShUrl(skill: MarketSkill) {
+	const sourceParts = skill.source.split("/").filter(Boolean);
+	const pathParts =
+		sourceParts[0] === "github" ? sourceParts.slice(1) : sourceParts;
+	const skillSegment = skill.slug || skill.name;
+	const urlSegments = [...pathParts, skillSegment]
+		.filter(Boolean)
+		.map((part) => encodeURIComponent(part));
+
+	return `${SKILLS_SH_BASE_URL}/${urlSegments.join("/")}`;
+}
 
 export default function SkillsSearchPage() {
 	const { t, i18n } = useTranslation();
@@ -102,6 +116,25 @@ export default function SkillsSearchPage() {
 	);
 
 	const hasMore = visibleCount < searchResults.length;
+
+	const handleCopySkillsShUrl = useCallback(
+		async (skill: MarketSkill) => {
+			const skillsShUrl = buildSkillsShUrl(skill);
+
+			try {
+				await writeText(skillsShUrl);
+				toast.success(t("skillsShLinkCopied"));
+			} catch (error) {
+				console.error("Failed to copy skills.sh URL:", error);
+				toast.danger(
+					error instanceof Error
+						? error.message
+						: t("skillsShLinkCopyFailed"),
+				);
+			}
+		},
+		[t],
+	);
 
 	const handleEndReached = useCallback(() => {
 		if (hasMore && !isFetching) {
@@ -170,38 +203,69 @@ export default function SkillsSearchPage() {
 						fixedItemHeight={ROW_HEIGHT}
 						style={{ height: "100%" }}
 						components={tableComponents}
-						itemContent={(_index, skill) => (
-							<>
-								<td className="p-2 align-middle">
-									<span className="font-medium">
-										{skill.name}
-									</span>
-								</td>
-								<td className="p-2 align-middle">
-									<span className="text-muted">
-										{compactFormatter.format(
-											skill.installs,
-										)}
-									</span>
-								</td>
-								<td className="p-2 align-middle">
-									<span className="text-muted text-sm">
-										{skill.source}
-									</span>
-								</td>
-								<td className="p-2 align-middle">
-									<Button
-										size="sm"
-										variant="tertiary"
-										onPress={() =>
-											handleInstallClick(skill)
-										}
-									>
-										{t("install")}
-									</Button>
-								</td>
-							</>
-						)}
+						itemContent={(_index, skill) => {
+							const skillsShUrl = buildSkillsShUrl(skill);
+
+							return (
+								<>
+									<td className="p-2 align-middle">
+										<span className="font-medium">
+											{skill.name}
+										</span>
+									</td>
+									<td className="p-2 align-middle">
+										<span className="text-muted">
+											{compactFormatter.format(
+												skill.installs,
+											)}
+										</span>
+									</td>
+									<td className="p-2 align-middle">
+										<Tooltip delay={0}>
+											<Tooltip.Trigger>
+												<button
+													type="button"
+													className="block max-w-full truncate text-left text-sm text-muted underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+													aria-label={t(
+														"copySkillsShLink",
+													)}
+													onClick={() => {
+														void handleCopySkillsShUrl(
+															skill,
+														);
+													}}
+												>
+													{skill.source}
+												</button>
+											</Tooltip.Trigger>
+											<Tooltip.Content className="max-w-80">
+												<div className="space-y-1">
+													<div className="break-all font-mono text-xs">
+														{skillsShUrl}
+													</div>
+													<div className="text-xs text-muted">
+														{t(
+															"copySkillsShLinkHint",
+														)}
+													</div>
+												</div>
+											</Tooltip.Content>
+										</Tooltip>
+									</td>
+									<td className="p-2 align-middle">
+										<Button
+											size="sm"
+											variant="tertiary"
+											onPress={() =>
+												handleInstallClick(skill)
+											}
+										>
+											{t("install")}
+										</Button>
+									</td>
+								</>
+							);
+						}}
 					>
 						<thead>
 							<tr>

--- a/crates/desktop/src/pages/skills-sh/search.tsx
+++ b/crates/desktop/src/pages/skills-sh/search.tsx
@@ -26,6 +26,20 @@ const FETCH_SIZE = 100;
 const ROW_HEIGHT = 48;
 const SKILLS_SH_BASE_URL = "https://www.skills.sh";
 
+function splitUrlPath(path: string) {
+	return path.split("/").filter(Boolean);
+}
+
+function normalizeSkillsShPathParts(parts: string[]) {
+	return parts[0] === "github" ? parts.slice(1) : parts;
+}
+
+function formatSkillsShUrl(parts: string[]) {
+	const urlSegments = parts.map((part) => encodeURIComponent(part));
+
+	return `${SKILLS_SH_BASE_URL}/${urlSegments.join("/")}`;
+}
+
 const tableComponents: TableComponents<MarketSkill> = {
 	Table: ({ style, ...props }) => (
 		<table
@@ -48,7 +62,12 @@ const tableComponents: TableComponents<MarketSkill> = {
 };
 
 function buildSkillsShUrl(skill: MarketSkill) {
-	const sourceParts = skill.source.split("/").filter(Boolean);
+	const slugParts = normalizeSkillsShPathParts(splitUrlPath(skill.slug));
+	if (slugParts.length > 1) {
+		return formatSkillsShUrl(slugParts);
+	}
+
+	const sourceParts = splitUrlPath(skill.source);
 	const pathParts = (() => {
 		if (sourceParts.length === 0) {
 			return [];
@@ -62,14 +81,16 @@ function buildSkillsShUrl(skill: MarketSkill) {
 			return sourceParts;
 		}
 
-		return ["site", ...sourceParts];
-	})();
-	const skillSegment = skill.slug || skill.name;
-	const urlSegments = [...pathParts, skillSegment]
-		.filter(Boolean)
-		.map((part) => encodeURIComponent(part));
+		if (sourceParts.length === 1 && sourceParts[0].includes(".")) {
+			return ["site", ...sourceParts];
+		}
 
-	return `${SKILLS_SH_BASE_URL}/${urlSegments.join("/")}`;
+		return sourceParts;
+	})();
+	const skillParts =
+		slugParts.length > 0 ? slugParts : splitUrlPath(skill.name);
+
+	return formatSkillsShUrl([...pathParts, ...skillParts]);
 }
 
 export default function SkillsSearchPage() {

--- a/crates/desktop/src/pages/skills-sh/search.tsx
+++ b/crates/desktop/src/pages/skills-sh/search.tsx
@@ -1,5 +1,5 @@
 import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
-import { Button, Spinner, Tooltip, toast } from "@heroui/react";
+import { Button, Spinner, toast } from "@heroui/react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useQueryState } from "nuqs";
@@ -213,8 +213,6 @@ export default function SkillsSearchPage() {
 						style={{ height: "100%" }}
 						components={tableComponents}
 						itemContent={(_index, skill) => {
-							const skillsShUrl = buildSkillsShUrl(skill);
-
 							return (
 								<>
 									<td className="p-2 align-middle">
@@ -230,36 +228,18 @@ export default function SkillsSearchPage() {
 										</span>
 									</td>
 									<td className="p-2 align-middle">
-										<Tooltip delay={0}>
-											<Tooltip.Trigger>
-												<button
-													type="button"
-													className="block max-w-full truncate text-left text-sm text-muted underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-													aria-label={t(
-														"copySkillsShLink",
-													)}
-													onClick={() => {
-														void handleCopySkillsShUrl(
-															skill,
-														);
-													}}
-												>
-													{skill.source}
-												</button>
-											</Tooltip.Trigger>
-											<Tooltip.Content className="max-w-80">
-												<div className="space-y-1">
-													<div className="break-all font-mono text-xs">
-														{skillsShUrl}
-													</div>
-													<div className="text-xs text-muted">
-														{t(
-															"copySkillsShLinkHint",
-														)}
-													</div>
-												</div>
-											</Tooltip.Content>
-										</Tooltip>
+										<button
+											type="button"
+											className="block max-w-full truncate text-left text-sm text-muted underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+											aria-label={t("copySkillsShLink")}
+											onClick={() => {
+												void handleCopySkillsShUrl(
+													skill,
+												);
+											}}
+										>
+											{skill.source}
+										</button>
 									</td>
 									<td className="p-2 align-middle">
 										<Button


### PR DESCRIPTION
## Summary
- make the skills.sh search result source value hover-underlined and clickable
- show a tooltip containing the derived skills.sh URL and copy hint
- copy the derived URL with Tauri clipboard feedback toasts

## Verification
- bunx prettier --write src/pages/skills-sh/search.tsx src/lib/locales/en.ts src/lib/locales/zh-Hans.ts src/lib/locales/zh-Hant.ts
- bun run typecheck
- bun run build

Closes KIT-48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now copy individual Skills.sh links directly from the search results table with a single click
  * Added localization support in English, Simplified Chinese, and Traditional Chinese with copy success and failure feedback messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->