### PR TITLE
fix(desktop): render UI before telemetry init to prevent white screen

### DIFF
--- a/crates/desktop/src/main.tsx
+++ b/crates/desktop/src/main.tsx
@@ -10,7 +10,19 @@ import {
 } from "./lib/analytics";
 import { log } from "./lib/logger";
 
-async function bootstrap() {
+// Mount the UI first and unconditionally. Telemetry and log setup go
+// through Tauri IPC, and a single rejected/hung command there must not
+// keep the window blank: rendering can't depend on analytics. The React
+// error boundary only catches failures inside a mounted tree, so any
+// throw before this render would leave a permanent white screen with no
+// recovery path.
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+);
+
+async function initTelemetry() {
 	try {
 		await attachConsole();
 		await info("Tauri log stream attached to frontend console");
@@ -18,22 +30,18 @@ async function bootstrap() {
 		console.error("Failed to attach Tauri log stream:", error);
 	}
 
-	// posthog-js needs the Rust-owned distinct_id before it boots so
-	// replay attaches to the same person as Rust-originated events.
-	await initBrowserPosthog();
-	installExceptionAutocapture();
-	capture("app started");
-	log.info("app started", {
-		"app.version": import.meta.env.VITE_APP_VERSION,
-	});
-
-	ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-		<React.StrictMode>
-			<App />
-		</React.StrictMode>,
-	);
+	try {
+		// posthog-js needs the Rust-owned distinct_id before it boots so
+		// replay attaches to the same person as Rust-originated events.
+		await initBrowserPosthog();
+		installExceptionAutocapture();
+		capture("app started");
+		log.info("app started", {
+			"app.version": import.meta.env.VITE_APP_VERSION,
+		});
+	} catch (error: unknown) {
+		console.error("Failed to initialize analytics:", error);
+	}
 }
 
-bootstrap().catch((error: unknown) => {
-	console.error("Failed to bootstrap desktop app:", error);
-});
+void initTelemetry();


### PR DESCRIPTION
## Problem

v1.2.2's macOS build launches to a permanent white screen (#236). The release was pulled and users were asked to roll back to v1.2.1.

## Root cause

Between v1.2.1 and v1.2.2, `crates/desktop/src/main.tsx` moved `ReactDOM.createRoot().render()` to run **after** `await initBrowserPosthog()`, with the whole bootstrap wrapped in a single `.catch()` that only logs.

As a result, any rejected or hung Tauri IPC call during bootstrap — log attach, `posthog_get_config`, store read, or `posthog.init` — aborts before the React tree mounts. The `ErrorBoundary` only catches failures inside a mounted tree, so the user is left staring at a blank window with no recovery path.

## Fix

Mount the UI first and unconditionally, then run analytics/log setup afterward, fully isolated so its failures only disable telemetry. This restores v1.2.1's guarantee that the UI always mounts while keeping v1.2.2's analytics feature.

## Verification

Reproduced in a WebKit (WKWebView-equivalent) load of the production bundle:

- Before: a rejecting Tauri store command during bootstrap leaves `#root` empty (white screen, no UI mounted).
- After: the same rejection still renders the app (`#root` mounts); normal denied/granted consent paths unaffected.

`tsc`, `vite build`, `prettier`, and `eslint` pass.

Fixes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved desktop application startup performance and reliability. The user interface now renders immediately instead of waiting for telemetry and logging initialization. These systems initialize asynchronously in the background, ensuring the app launches reliably even if analytics or logging setup encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->