### PR TITLE
fix(core): suppress Windows console window when validating agent config

### DIFF
--- a/crates/core/src/adapter.rs
+++ b/crates/core/src/adapter.rs
@@ -235,6 +235,13 @@ impl AgentAdapter for &'static AgentDescriptor {
 		if let Some(config_path) = config_path {
 			cmd.arg(config_path);
 		}
+		// `validate` runs this from the console-less desktop app; suppress the
+		// console window Windows would otherwise pop for the agent CLI.
+		#[cfg(target_os = "windows")]
+		{
+			use std::os::windows::process::CommandExt;
+			cmd.creation_flags(crate::CREATE_NO_WINDOW);
+		}
 		cmd
 	}
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,12 @@ pub mod registry;
 pub mod skills;
 pub mod transfer;
 
+/// Windows `CREATE_NO_WINDOW` process-creation flag. Subprocesses spawned from
+/// the console-less desktop app would otherwise flash a console window; callers
+/// OR this into `creation_flags` on Windows (see `ConfigManager::validate`).
+#[cfg(windows)]
+pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 pub use aghub_agents::{descriptor, errors, format, models};
 pub use aghub_agents::{
 	AgentConfig, AgentDescriptor, AgentType, Capabilities, ConfigError,


### PR DESCRIPTION
## What

`ConfigManager::validate` runs each agent's validation CLI via the `Command`
returned by `validate_command`. On Windows, spawning it from the console-less
desktop app flashes a console window for the child process.

This sets `CREATE_NO_WINDOW` on that command, matching the convention the
`api`, `cc-plugins`, and `desktop` crates already follow for their own child
processes.

## Why

Surfaced while auditing Windows console-window handling for #193 (usage
monitoring). Every other production subprocess reachable from the desktop GUI
already sets the flag; `validate_command` was the one remaining gap. It isn't
exposed over the embedded API today (only the CLI calls `validate`, which has a
console), so this is a latent fix rather than a live regression — but it keeps
the convention complete for whenever validation is wired into the desktop.

## How

- Add `CREATE_NO_WINDOW` to `aghub-core` (`#[cfg(windows)]`), mirroring the
  `api` / `cc-plugins` definitions.
- Apply it in `validate_command` (its only caller is `validate`), so the agent
  CLI runs windowless. `cmd` is already `mut` from building args, so no
  non-Windows lint fallout.

## Verification

- `cargo clippy -p aghub-core --all-targets -- -D warnings` ✅
- Windows-only code path verified by source inspection against the identical
  `std::os::windows::process::CommandExt::creation_flags` usage already in the
  api routes (cross-compiling to Windows from macOS is blocked by an unrelated
  C build-dependency); a real Windows build is the final confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows behavior so the app no longer briefly opens a console window when launching subprocesses from the desktop experience.
  * Kept behavior unchanged on non-Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->