### PR TITLE
fix: agent config-folder paths (backend source of truth + 3 descriptor corrections)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ name = "aghub"
 version = "0.0.0"
 dependencies = [
  "aghub-api",
+ "aghub-core",
  "base64 0.22.1",
  "dotenvy",
  "fix-path-env",

--- a/crates/agents/src/agents/augmentcode.rs
+++ b/crates/agents/src/agents/augmentcode.rs
@@ -1,10 +1,41 @@
-use crate::define_mcp_paths;
 use crate::descriptor::*;
+use std::path::{Path, PathBuf};
 
-define_mcp_paths! {
-	symmetric: ".augmentcode/mcp.json",
-	strategy: mcp_strategy::parse_json_map_mcp_servers,
-			  mcp_strategy::serialize_json_map_mcp_servers,
+// The Auggie CLI persists MCP servers in ~/.augment/settings.json (a top-level
+// "mcpServers" map). There is no project-level MCP file — project servers are
+// per-run via `--mcp-config` only — and the IDE extension is GUI-managed.
+// See https://docs.augmentcode.com/cli/integrations.
+fn mcp_global_path() -> Option<PathBuf> {
+	home_dir().map(|home| home.join(".augment/settings.json"))
+}
+fn global_data_dir() -> Option<PathBuf> {
+	home_dir().map(|home| home.join(".augment"))
+}
+fn load_mcps(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+) -> crate::Result<Vec<crate::McpServer>> {
+	load_scoped_mcps(
+		project_root,
+		scope,
+		Some(mcp_global_path),
+		None,
+		mcp_strategy::parse_json_map_mcp_servers,
+	)
+}
+fn save_mcps(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+	mcps: &[crate::McpServer],
+) -> crate::Result<()> {
+	save_scoped_mcps(
+		project_root,
+		scope,
+		mcps,
+		Some(mcp_global_path),
+		None,
+		mcp_strategy::serialize_json_map_mcp_servers,
+	)
 }
 
 pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
@@ -15,7 +46,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	load_mcps,
 	save_mcps,
 	mcp_global_path: Some(mcp_global_path),
-	mcp_project_path: Some(mcp_project_path),
+	mcp_project_path: None,
 	global_data_dir,
 	capabilities: Capabilities {
 		skills: SkillCapabilities {
@@ -28,7 +59,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 		mcp: McpCapabilities {
 			scopes: ScopeSupport {
 				global: true,
-				project: true,
+				project: false,
 			},
 			stdio: true,
 			remote: true,
@@ -47,6 +78,6 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	save_sub_agents: save_sub_agents_noop,
 	cli_name: "augmentcode",
 	validate_args: &["--version"],
-	project_markers: &[".augmentcode"],
+	project_markers: &[],
 	skills_cli_name: Some("augment"),
 };

--- a/crates/agents/src/agents/jetbrains_ai.rs
+++ b/crates/agents/src/agents/jetbrains_ai.rs
@@ -1,21 +1,45 @@
-use crate::define_mcp_paths;
 use crate::descriptor::*;
+use crate::errors::ConfigError;
+use std::path::{Path, PathBuf};
 
-define_mcp_paths! {
-	symmetric: ".jetbrains-ai/mcp.json",
-	strategy: mcp_strategy::parse_json_map_mcp_servers,
-			  mcp_strategy::serialize_json_map_mcp_servers,
+// JetBrains AI Assistant configures MCP only through the IDE GUI (Settings |
+// Tools | AI Assistant | Model Context Protocol), with a global/project "Level"
+// and "Import from Claude". There is no externally-writable config file, so
+// aghub does not manage MCP for it. (Junie — a different JetBrains agent — is
+// file-based at ~/.junie/mcp/mcp.json, but that is a separate product.)
+// See https://www.jetbrains.com/help/ai-assistant/configure-an-mcp-server.html.
+fn global_data_dir() -> Option<PathBuf> {
+	// Detect a JetBrains install via the OS config dir:
+	// ~/Library/Application Support/JetBrains (macOS), ~/.config/JetBrains (Linux).
+	dirs::config_dir().map(|dir| dir.join("JetBrains"))
+}
+fn load_mcps(
+	_: Option<&Path>,
+	_: crate::ResourceScope,
+) -> crate::Result<Vec<crate::McpServer>> {
+	Ok(Vec::new())
+}
+fn save_mcps(
+	_: Option<&Path>,
+	_: crate::ResourceScope,
+	_: &[crate::McpServer],
+) -> crate::Result<()> {
+	Err(ConfigError::unsupported_operation(
+		"persist",
+		"MCP server",
+		"jetbrains-ai",
+	))
 }
 
 pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	id: "jetbrains-ai",
 	display_name: "JetBrains AI",
-	mcp_parse_config: Some(mcp_strategy::parse_json_map_mcp_servers),
-	mcp_serialize_config: Some(mcp_strategy::serialize_json_map_mcp_servers),
+	mcp_parse_config: None,
+	mcp_serialize_config: None,
 	load_mcps,
 	save_mcps,
-	mcp_global_path: Some(mcp_global_path),
-	mcp_project_path: Some(mcp_project_path),
+	mcp_global_path: None,
+	mcp_project_path: None,
 	global_data_dir,
 	capabilities: Capabilities {
 		skills: SkillCapabilities {
@@ -27,11 +51,11 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 		},
 		mcp: McpCapabilities {
 			scopes: ScopeSupport {
-				global: true,
-				project: true,
+				global: false,
+				project: false,
 			},
-			stdio: true,
-			remote: true,
+			stdio: false,
+			remote: false,
 			enable_disable: false,
 		},
 		sub_agents: SubAgentCapabilities {
@@ -47,6 +71,6 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	save_sub_agents: save_sub_agents_noop,
 	cli_name: "jetbrains",
 	validate_args: &["--version"],
-	project_markers: &[".jetbrains-ai"],
+	project_markers: &[],
 	skills_cli_name: None,
 };

--- a/crates/agents/src/agents/trae.rs
+++ b/crates/agents/src/agents/trae.rs
@@ -1,15 +1,50 @@
-use crate::define_mcp_paths;
-use crate::define_skill_paths;
 use crate::descriptor::*;
+use std::path::{Path, PathBuf};
 
-define_mcp_paths! {
-	symmetric: ".trae/mcp.json",
-	strategy: mcp_strategy::parse_json_map_mcp_servers,
-			  mcp_strategy::serialize_json_map_mcp_servers,
+// Trae configures MCP through its GUI (Settings > MCP); there is no documented
+// hand-editable GLOBAL file — the global store is the IDE's opaque app data.
+// Only the project-level `.trae/` directory (mcp.json, skills, rules) is real.
+// See https://docs.trae.ai and https://github.com/trae-community/trae-mcp.
+fn mcp_project_path(root: &Path) -> Option<PathBuf> {
+	Some(root.join(".trae/mcp.json"))
 }
-
-define_skill_paths! {
-	symmetric: ".trae/skills",
+fn global_data_dir() -> Option<PathBuf> {
+	// Trae is a VS Code fork: its app data lives in the OS config dir —
+	// ~/Library/Application Support/Trae (macOS), ~/.config/Trae (Linux),
+	// %APPDATA%\Trae (Windows). Used for availability/reveal, not for writing.
+	dirs::config_dir().map(|dir| dir.join("Trae"))
+}
+fn load_mcps(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+) -> crate::Result<Vec<crate::McpServer>> {
+	load_scoped_mcps(
+		project_root,
+		scope,
+		None,
+		Some(mcp_project_path),
+		mcp_strategy::parse_json_map_mcp_servers,
+	)
+}
+fn save_mcps(
+	project_root: Option<&Path>,
+	scope: crate::ResourceScope,
+	mcps: &[crate::McpServer],
+) -> crate::Result<()> {
+	save_scoped_mcps(
+		project_root,
+		scope,
+		mcps,
+		None,
+		Some(mcp_project_path),
+		mcp_strategy::serialize_json_map_mcp_servers,
+	)
+}
+fn project_skills_paths(root: &Path) -> Vec<PathBuf> {
+	vec![root.join(".trae/skills")]
+}
+fn project_skill_write_path(root: &Path) -> Option<PathBuf> {
+	Some(root.join(".trae/skills"))
 }
 
 pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
@@ -19,20 +54,20 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 	mcp_serialize_config: Some(mcp_strategy::serialize_json_map_mcp_servers),
 	load_mcps,
 	save_mcps,
-	mcp_global_path: Some(mcp_global_path),
+	mcp_global_path: None,
 	mcp_project_path: Some(mcp_project_path),
 	global_data_dir,
 	capabilities: Capabilities {
 		skills: SkillCapabilities {
 			scopes: ScopeSupport {
-				global: true,
+				global: false,
 				project: true,
 			},
 			universal: false,
 		},
 		mcp: McpCapabilities {
 			scopes: ScopeSupport {
-				global: true,
+				global: false,
 				project: true,
 			},
 			stdio: true,
@@ -46,10 +81,7 @@ pub const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
 			},
 		},
 	},
-	global_skill_paths: Some(GlobalSkillPaths {
-		read: global_skills_paths,
-		write: global_skill_write_path,
-	}),
+	global_skill_paths: None,
 	project_skill_paths: Some(ProjectSkillPaths {
 		read: project_skills_paths,
 		write: project_skill_write_path,

--- a/crates/agents/tests/descriptor_regression.rs
+++ b/crates/agents/tests/descriptor_regression.rs
@@ -192,12 +192,12 @@ fn test_project_markers() {
 		(AgentType::Windsurf, &[".windsurf"]),
 		(AgentType::Trae, &[".trae"]),
 		(AgentType::Zed, &[".zed"]),
-		(AgentType::JetBrainsAi, &[".jetbrains-ai"]),
+		(AgentType::JetBrainsAi, &[]),
 		(AgentType::RooCode, &[".roo"]),
 		(AgentType::Kimi, &[".kimi"]),
 		(AgentType::Mistral, &[".vibe"]),
 		(AgentType::Pi, &[".pi"]),
-		(AgentType::AugmentCode, &[".augmentcode"]),
+		(AgentType::AugmentCode, &[]),
 		(AgentType::KiloCode, &[".kilocode"]),
 		(AgentType::Amp, &[".amp"]),
 		(AgentType::Warp, &[".warp"]),
@@ -246,14 +246,14 @@ fn test_mcp_global_paths() {
 			AgentType::Windsurf,
 			Some(".codeium/windsurf/mcp_config.json"),
 		),
-		(AgentType::Trae, Some(".trae/mcp.json")),
+		(AgentType::Trae, None), // global MCP is GUI-managed (no file)
 		(AgentType::Zed, Some(".config/zed/settings.json")),
-		(AgentType::JetBrainsAi, Some(".jetbrains-ai/mcp.json")),
+		(AgentType::JetBrainsAi, None), // MCP is GUI-only (no file)
 		(AgentType::RooCode, Some(".roo/mcp.json")),
 		(AgentType::Kimi, Some(".kimi/mcp.json")),
 		(AgentType::Mistral, Some(".vibe/mcp.toml")),
 		(AgentType::Pi, None), // Pi has no MCP
-		(AgentType::AugmentCode, Some(".augmentcode/mcp.json")),
+		(AgentType::AugmentCode, Some(".augment/settings.json")),
 		(AgentType::KiloCode, Some(".kilocode/mcp.json")),
 		(AgentType::Amp, Some(".config/amp/settings.json")),
 		(AgentType::Warp, Some(".warp/mcp.json")),
@@ -315,12 +315,12 @@ fn test_mcp_project_paths() {
 		(AgentType::Windsurf, Some(".windsurf/mcp_config.json")),
 		(AgentType::Trae, Some(".trae/mcp.json")),
 		(AgentType::Zed, Some(".zed/settings.json")),
-		(AgentType::JetBrainsAi, Some(".jetbrains-ai/mcp.json")),
+		(AgentType::JetBrainsAi, None), // MCP is GUI-only (no file)
 		(AgentType::RooCode, Some(".roo/mcp.json")),
 		(AgentType::Kimi, Some(".kimi/mcp.json")),
 		(AgentType::Mistral, Some(".vibe/mcp.toml")),
-		(AgentType::Pi, None), // Pi has no MCP
-		(AgentType::AugmentCode, Some(".augmentcode/mcp.json")),
+		(AgentType::Pi, None),          // Pi has no MCP
+		(AgentType::AugmentCode, None), // CLI has no project MCP file
 		(AgentType::KiloCode, Some(".kilocode/mcp.json")),
 		(AgentType::Amp, Some(".amp/mcp.json")),
 		(AgentType::Warp, Some(".warp/mcp.json")),
@@ -367,7 +367,7 @@ fn test_mcp_project_paths() {
 
 #[test]
 fn test_global_data_dirs() {
-	let expected: [(AgentType, Option<&str>); 22] = [
+	let expected: [(AgentType, Option<&str>); 20] = [
 		(AgentType::Claude, Some(".claude")),
 		(AgentType::Codex, Some(".codex")),
 		(AgentType::Openclaw, Some(".openclaw")),
@@ -379,14 +379,14 @@ fn test_global_data_dirs() {
 		(AgentType::Antigravity, Some(".gemini/antigravity")),
 		(AgentType::Kiro, Some(".kiro")),
 		(AgentType::Windsurf, Some(".codeium/windsurf")),
-		(AgentType::Trae, Some(".trae")),
+		// Trae and JetBrainsAi use the OS config dir, not a home dotfolder —
+		// asserted explicitly after the loop.
 		(AgentType::Zed, Some(".config/zed")),
-		(AgentType::JetBrainsAi, Some(".jetbrains-ai")),
 		(AgentType::RooCode, Some(".roo")),
 		(AgentType::Kimi, Some(".kimi")),
 		(AgentType::Mistral, Some(".vibe")),
 		(AgentType::Pi, Some(".pi/agent")),
-		(AgentType::AugmentCode, Some(".augmentcode")),
+		(AgentType::AugmentCode, Some(".augment")),
 		(AgentType::KiloCode, Some(".kilocode")),
 		(AgentType::Amp, Some(".config/amp")),
 		(AgentType::Warp, Some(".warp")),
@@ -419,6 +419,20 @@ fn test_global_data_dirs() {
 			None => {}
 		}
 	}
+
+	// Trae and JetBrains AI store data in the OS config dir (Application
+	// Support on macOS, .config on Linux), not a home dotfolder.
+	use aghub_agents::agents;
+	assert_eq!(
+		(agents::trae::DESCRIPTOR.global_data_dir)(),
+		dirs::config_dir().map(|c| c.join("Trae")),
+		"trae global_data_dir should be the OS config dir"
+	);
+	assert_eq!(
+		(agents::jetbrains_ai::DESCRIPTOR.global_data_dir)(),
+		dirs::config_dir().map(|c| c.join("JetBrains")),
+		"jetbrains-ai global_data_dir should be the OS config dir"
+	);
 }
 
 // =============================================================================
@@ -441,7 +455,7 @@ fn test_mcp_capabilities_stdio() {
 		(AgentType::Windsurf, true),
 		(AgentType::Trae, true),
 		(AgentType::Zed, true),
-		(AgentType::JetBrainsAi, true),
+		(AgentType::JetBrainsAi, false), // GUI-only, no file-based MCP
 		(AgentType::RooCode, true),
 		(AgentType::Kimi, true),
 		(AgentType::Mistral, true),
@@ -480,7 +494,7 @@ fn test_mcp_capabilities_remote() {
 		(AgentType::Windsurf, true),
 		(AgentType::Trae, true),
 		(AgentType::Zed, true),
-		(AgentType::JetBrainsAi, true),
+		(AgentType::JetBrainsAi, false), // GUI-only, no file-based MCP
 		(AgentType::RooCode, true),
 		(AgentType::Kimi, true),
 		(AgentType::Mistral, true),
@@ -517,9 +531,9 @@ fn test_mcp_capabilities_scopes_global() {
 		(AgentType::Antigravity, true),
 		(AgentType::Kiro, true),
 		(AgentType::Windsurf, true),
-		(AgentType::Trae, true),
+		(AgentType::Trae, false), // global MCP is GUI-managed
 		(AgentType::Zed, true),
-		(AgentType::JetBrainsAi, true),
+		(AgentType::JetBrainsAi, false), // GUI-only, no file-based MCP
 		(AgentType::RooCode, true),
 		(AgentType::Kimi, true),
 		(AgentType::Mistral, true),
@@ -558,12 +572,12 @@ fn test_mcp_capabilities_scopes_project() {
 		(AgentType::Windsurf, true),
 		(AgentType::Trae, true),
 		(AgentType::Zed, true),
-		(AgentType::JetBrainsAi, true),
+		(AgentType::JetBrainsAi, false), // GUI-only, no file-based MCP
 		(AgentType::RooCode, true),
 		(AgentType::Kimi, true),
 		(AgentType::Mistral, true),
-		(AgentType::Pi, false), // Pi has no MCP
-		(AgentType::AugmentCode, true),
+		(AgentType::Pi, false),          // Pi has no MCP
+		(AgentType::AugmentCode, false), // CLI has no project MCP file
 		(AgentType::KiloCode, true),
 		(AgentType::Amp, true),
 		(AgentType::Warp, true),
@@ -599,8 +613,8 @@ fn test_skills_capabilities_scopes_global() {
 		(AgentType::Antigravity, true),
 		(AgentType::Kiro, true),
 		(AgentType::Windsurf, true),
-		(AgentType::Trae, true),
-		(AgentType::Zed, false), // Zed has no global skills
+		(AgentType::Trae, false), // global skills are not attested
+		(AgentType::Zed, false),  // Zed has no global skills
 		(AgentType::JetBrainsAi, false),
 		(AgentType::RooCode, true),
 		(AgentType::Kimi, true),
@@ -820,7 +834,7 @@ fn test_global_skill_paths() {
 		),
 		(AgentType::Kiro, Some(&[".kiro/skills"])),
 		(AgentType::Windsurf, Some(&[".codeium/windsurf/skills"])),
-		(AgentType::Trae, Some(&[".trae/skills"])),
+		(AgentType::Trae, None),
 		(AgentType::Zed, None), // Zed has no skills
 		(AgentType::JetBrainsAi, None),
 		(AgentType::RooCode, Some(&[".roo/skills"])),

--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -6,6 +6,7 @@
 use aghub_core::{
 	models::{AgentType, McpServer, McpTransport, Skill},
 	testing::{TestConfig, TestConfigBuilder},
+	ConfigManager,
 };
 use std::collections::HashMap;
 
@@ -680,8 +681,6 @@ test_mcp_workflow! {
 	test_amp_mcp_workflow => AgentType::Amp, "amp-mcp",
 	test_augmentcode_mcp_workflow => AgentType::AugmentCode, "augmentcode-mcp",
 	test_warp_mcp_workflow => AgentType::Warp, "warp-mcp",
-	test_trae_mcp_workflow => AgentType::Trae, "trae-mcp",
-	test_jetbrains_ai_mcp_workflow => AgentType::JetBrainsAi, "jetbrains-ai-mcp",
 }
 
 #[test]
@@ -697,6 +696,60 @@ fn test_pi_rejects_mcp_workflow() {
 		err,
 		aghub_core::errors::ConfigError::UnsupportedOperation(_)
 	));
+}
+
+// Trae configures MCP through its GUI; only project scope is file-based, so a
+// global add is rejected.
+#[test]
+fn test_trae_rejects_global_mcp() {
+	let test = TestConfig::new(AgentType::Trae).unwrap();
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+
+	let err = manager
+		.add_mcp(create_test_mcp_stdio("trae-mcp"))
+		.unwrap_err();
+	assert!(matches!(
+		err,
+		aghub_core::errors::ConfigError::UnsupportedOperation(_)
+	));
+}
+
+// JetBrains AI Assistant configures MCP only via the IDE GUI — no scope is
+// file-based, so any add is rejected.
+#[test]
+fn test_jetbrains_ai_rejects_mcp() {
+	let test = TestConfig::new(AgentType::JetBrainsAi).unwrap();
+	let mut manager = test.create_manager();
+	manager.load().unwrap();
+
+	let err = manager
+		.add_mcp(create_test_mcp_stdio("jetbrains-mcp"))
+		.unwrap_err();
+	assert!(matches!(
+		err,
+		aghub_core::errors::ConfigError::UnsupportedOperation(_)
+	));
+}
+
+// Trae's project scope IS file-based — the add/get/remove roundtrip works,
+// complementing the global rejection above.
+#[test]
+fn test_trae_project_mcp_roundtrip() {
+	let test = TestConfig::new(AgentType::Trae).unwrap();
+	let adapter = test.create_adapter();
+	let mut manager = ConfigManager::new(adapter, false, Some(test.temp_dir()));
+	manager.load().unwrap();
+
+	manager.add_mcp(create_test_mcp_stdio("trae-mcp")).unwrap();
+	manager.load().unwrap();
+	let config = manager.config().unwrap();
+	assert_eq!(config.mcps.len(), 1);
+	assert_eq!(config.mcps[0].name, "trae-mcp");
+
+	manager.remove_mcp("trae-mcp").unwrap();
+	manager.load().unwrap();
+	assert!(manager.config().unwrap().mcps.is_empty());
 }
 
 // ==================== Special Case: Agent-Specific Key Tests ====================

--- a/crates/desktop/src-tauri/Cargo.toml
+++ b/crates/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-log = { version = "2.8.0", features = [ "colored" ] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 aghub-api = { path = "../../api" }
+aghub-core = { path = "../../core" }
 tokio = { workspace = true, features = [ "rt" ] }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
 log = { workspace = true }

--- a/crates/desktop/src-tauri/src/commands/agents.rs
+++ b/crates/desktop/src-tauri/src/commands/agents.rs
@@ -1,0 +1,52 @@
+use std::str::FromStr;
+
+use aghub_core::models::AgentType;
+use aghub_core::registry;
+
+/// Resolve an agent's global config directory as an absolute, OS-correct path
+/// for the desktop "open config folder" action.
+///
+/// The agent descriptor's `global_data_dir` (built on `dirs::home_dir()`) is the
+/// single source of truth, so platform conventions live in one place on the
+/// backend rather than being reconstructed in the renderer. Returns `None` for
+/// an unknown agent id or when no home directory is available, so the caller
+/// hides the button.
+#[tauri::command]
+pub fn agent_config_dir(agent_id: String) -> Option<String> {
+	let agent_type = AgentType::from_str(&agent_id).ok()?;
+	let dir = (registry::get(agent_type).global_data_dir)()?;
+	Some(dir.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn slash(path: String) -> String {
+		path.replace('\\', "/")
+	}
+
+	#[test]
+	fn resolves_known_agents_to_their_config_dir() {
+		let claude =
+			agent_config_dir("claude".into()).expect("claude config dir");
+		assert!(slash(claude).ends_with("/.claude"));
+
+		let opencode =
+			agent_config_dir("opencode".into()).expect("opencode config dir");
+		assert!(slash(opencode).ends_with("/.config/opencode"));
+	}
+
+	#[test]
+	fn accepts_id_aliases() {
+		// `from_str` maps "roo" → RooCode, whose data dir is `.roo`.
+		let roo = agent_config_dir("roo".into()).expect("roo alias resolves");
+		assert!(slash(roo).ends_with("/.roo"));
+	}
+
+	#[test]
+	fn unknown_agent_id_is_none() {
+		// Unknown ids must not silently fall back to Claude's directory.
+		assert_eq!(agent_config_dir("does-not-exist".into()), None);
+	}
+}

--- a/crates/desktop/src-tauri/src/commands/mod.rs
+++ b/crates/desktop/src-tauri/src/commands/mod.rs
@@ -1,8 +1,10 @@
+pub mod agents;
 pub mod logging;
 pub mod posthog;
 pub mod server;
 pub mod window;
 
+pub use agents::agent_config_dir;
 pub use logging::{
 	clear_log_files, export_diagnostic_logs, get_log_dir_path, get_log_entries,
 	get_log_stats,

--- a/crates/desktop/src-tauri/src/lib.rs
+++ b/crates/desktop/src-tauri/src/lib.rs
@@ -1,8 +1,9 @@
 use crate::commands::{
-	clear_log_files, export_diagnostic_logs, get_log_dir_path, get_log_entries,
-	get_log_stats, minimize_to_tray, posthog_capture, posthog_get_config,
-	posthog_get_distinct_id, posthog_get_session_id, posthog_identify,
-	posthog_set_enabled, start_server,
+	agent_config_dir, clear_log_files, export_diagnostic_logs,
+	get_log_dir_path, get_log_entries, get_log_stats, minimize_to_tray,
+	posthog_capture, posthog_get_config, posthog_get_distinct_id,
+	posthog_get_session_id, posthog_identify, posthog_set_enabled,
+	start_server,
 };
 use log::info;
 use tauri::{Manager, WebviewWindow};
@@ -306,6 +307,7 @@ pub fn run() {
 			Ok(())
 		})
 		.invoke_handler(tauri::generate_handler![
+			agent_config_dir,
 			start_server,
 			export_diagnostic_logs,
 			get_log_dir_path,

--- a/crates/desktop/src/lib/agent-config-paths.ts
+++ b/crates/desktop/src/lib/agent-config-paths.ts
@@ -1,43 +1,19 @@
-import { homeDir, join } from "@tauri-apps/api/path";
+import { invoke } from "@tauri-apps/api/core";
 import type { AgentInfo } from "../generated/dto";
 
-const KNOWN_AGENT_RELATIVE_PATHS: Record<string, string[]> = {
-	claude: [".claude.json"],
-	codex: [".codex", "config.toml"],
-	opencode: [".config", "opencode", "opencode.json"],
-	cursor: [".cursor"],
-	windsurf: [".codeium", "windsurf"],
-	zed: [".config", "zed"],
-	warp: [".warp"],
-	copilot: [".copilot"],
-	cline: [".cline"],
-	gemini: [".gemini", "settings.json"],
-	roocode: [".roo"],
-	mistral: [".vibe"],
-	amp: [".config", "amp"],
-};
-
 /**
- * Resolve a filesystem path that we can hand to revealItemInDir for an agent.
+ * Resolve the absolute, OS-correct config directory for an agent's "open config
+ * folder" button.
  *
- * Strategy:
- * 1. Look up a hardcoded relative-to-home path for known agents (most accurate
- *    — points at the actual config file or directory).
- * 2. Fall back to the agent's global skills write directory if it has one.
- * 3. Return null if neither is known (caller should hide the button).
+ * The backend is the single source of truth: the `agent_config_dir` Tauri
+ * command reads the agent descriptor's `global_data_dir` (built on the `dirs`
+ * crate) and returns a platform-correct absolute path, so the renderer hands the
+ * result straight to `revealItemInDir` — no `~` expansion or path reconstruction
+ * here. Returns `null` when the agent has no config dir, so the caller hides the
+ * button.
  */
 export async function resolveAgentConfigPath(
 	agent: AgentInfo,
 ): Promise<string | null> {
-	const known = KNOWN_AGENT_RELATIVE_PATHS[agent.id];
-	if (known) {
-		const home = await homeDir();
-		return join(home, ...known);
-	}
-
-	if (agent.skills_paths.global_write) {
-		return agent.skills_paths.global_write;
-	}
-
-	return null;
+	return invoke<string | null>("agent_config_dir", { agentId: agent.id });
 }


### PR DESCRIPTION
## Summary

Surfaced from the #282 (agent-hub-revamp) review, which flagged the desktop "open config folder" paths as hardcoded/drifting. Two related changes (one commit each):

### 1. Resolve the config dir from the backend descriptor — `feat`

The home agent card's "open config folder" button hardcoded a `KNOWN_AGENT_RELATIVE_PATHS` table in the renderer, duplicating the Rust agent descriptors and ignoring `XDG_CONFIG_HOME`.

- New `agent_config_dir` Tauri command resolves the descriptor's `global_data_dir` to an absolute, OS-correct path.
- `agent-config-paths.ts` now invokes it; `KNOWN_AGENT_RELATIVE_PATHS` is gone.
- Absolute paths travel over the Tauri IPC channel — not the HTTP API, which keeps tilde-formatted display paths per `crates/api/CLAUDE.md` — matching the existing `homeDir`/`app_data_dir` usage.
- The button still hides when an agent has no config dir.

### 2. Correct three wrong descriptors — `fix`

An audit found three descriptors declaring global MCP/skill files the agents never read (the path macros derived everything from invented home dotfolders):

| agent | before | after |
|---|---|---|
| augmentcode | `~/.augmentcode/mcp.json` | `~/.augment/settings.json` (the Auggie CLI's real file); project MCP dropped; fabricated `.augmentcode` marker removed |
| trae | `~/.trae/mcp.json` + `~/.trae/skills` (global) | global dropped (GUI-managed); project `.trae/...` kept; `global_data_dir` → OS config dir (`~/Library/Application Support/Trae`, etc.) |
| jetbrains-ai | `~/.jetbrains-ai/mcp.json` | MCP marked unsupported (GUI-only, no writable file) |

Confidence: augmentcode is high (verbatim in docs.augmentcode.com); trae and jetbrains-ai are medium — based on the absence of any documented externally-writable file, which is standard for these GUI apps. The other 20 agents were audited and confirmed correct.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test` — including new `agent_config_dir` unit tests, trae/jetbrains MCP-rejection tests, the augmentcode global-MCP roundtrip, and updated descriptor-regression + integration tables
- `cd crates/desktop && bun run typecheck && bun run lint && bun run build`
- Ran `agent_config_dir` against all 23 agents on macOS: every installed agent resolves to its real, existing config directory


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new way to open an agent’s configuration folder from the desktop app.
  * Improved support for resolving agent config locations across different environments.

* **Bug Fixes**
  * Updated agent settings handling so some agents now use the correct project-only or global-only storage location.
  * Fixed behavior for agents that no longer support certain MCP configuration options.
  * Refreshed tests to match the updated agent configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->