### PR TITLE
fix(desktop): agent-hub-revamp follow-up fixes

### DIFF
--- a/crates/desktop/src/App.tsx
+++ b/crates/desktop/src/App.tsx
@@ -231,7 +231,11 @@ function App() {
 										<Redirect to="/market" />
 									</Route>
 									<Route path="/library/search">
-										<Redirect to="/market/search" />
+										{() => (
+											<Redirect
+												to={`/market/search${window.location.search}`}
+											/>
+										)}
 									</Route>
 
 									<Route path="/skills">
@@ -278,7 +282,11 @@ function App() {
 										<Redirect to="/market" />
 									</Route>
 									<Route path="/skills-sh/search">
-										<Redirect to="/market/search" />
+										{() => (
+											<Redirect
+												to={`/market/search${window.location.search}`}
+											/>
+										)}
 									</Route>
 
 									<Route path="/cc-plugins">

--- a/crates/desktop/src/components/global-search.tsx
+++ b/crates/desktop/src/components/global-search.tsx
@@ -133,6 +133,7 @@ export function GlobalSearch() {
 			{showPopover && (
 				<div
 					role="listbox"
+					aria-label={t("globalSearchLabel")}
 					className="absolute left-0 right-0 top-full z-50 mt-1 max-h-[60vh] overflow-y-auto rounded-md border border-border bg-surface shadow-lg"
 				>
 					{flatMatches.length === 0 && !isMarketFetching ? (

--- a/crates/desktop/src/components/resource-page-toolbar.tsx
+++ b/crates/desktop/src/components/resource-page-toolbar.tsx
@@ -78,16 +78,13 @@ function AgentFilterControl({ agentId, onChange }: AgentFilterControlProps) {
 	const { t } = useTranslation();
 	const { availableAgents } = useAgentAvailability();
 
+	// Only offer usable agents as filters; disabled agents are filtered back out
+	// by the resource lists downstream, so selecting one would show an empty page.
 	const installedAgents = useMemo(
 		() =>
 			[...availableAgents]
-				.filter((agent) => agent.availability.is_available)
-				.sort((a, b) => {
-					if (a.isDisabled !== b.isDisabled) {
-						return a.isDisabled ? 1 : -1;
-					}
-					return a.display_name.localeCompare(b.display_name);
-				}),
+				.filter((agent) => agent.isUsable)
+				.sort((a, b) => a.display_name.localeCompare(b.display_name)),
 		[availableAgents],
 	);
 

--- a/crates/desktop/src/hooks/use-global-search.ts
+++ b/crates/desktop/src/hooks/use-global-search.ts
@@ -61,17 +61,22 @@ export function useGlobalSearch({
 		[availableAgents],
 	);
 
+	const trimmed = query.trim();
+
+	// Defer the local resource lists until the user actually searches — this
+	// hook is mounted from the sidebar on every page.
 	const { data: skills = [] } = useQuery({
 		...skillListQueryOptions({ api, scope: "global" }),
+		enabled: trimmed.length > 0,
 	});
 	const { data: mcps = [] } = useQuery({
 		...mcpListQueryOptions({ api, scope: "global" }),
+		enabled: trimmed.length > 0,
 	});
 	const { data: subAgents = [] } = useQuery({
 		...subAgentListQueryOptions({ api, scope: "global" }),
+		enabled: trimmed.length > 0,
 	});
-
-	const trimmed = query.trim();
 	const debouncedTrimmed = useDebouncedValue(trimmed, LIBRARY_DEBOUNCE_MS);
 
 	const { data: marketResults = [], isFetching: isMarketFetching } = useQuery<

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -916,6 +916,7 @@ export default {
 		math: "Math",
 		migration: "Migration",
 		monitoring: "Monitoring",
+		other: "Other",
 		productivity: "Productivity",
 		search: "Search",
 		security: "Security",

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -903,6 +903,7 @@ export default {
 		math: "数学",
 		migration: "迁移",
 		monitoring: "监控",
+		other: "其他",
 		productivity: "生产力",
 		search: "搜索",
 		security: "安全",

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -899,6 +899,7 @@ export default {
 		math: "數學",
 		migration: "遷移",
 		monitoring: "監控",
+		other: "其他",
 		productivity: "生產力",
 		search: "搜尋",
 		security: "安全",

--- a/crates/desktop/src/pages/home.tsx
+++ b/crates/desktop/src/pages/home.tsx
@@ -58,20 +58,16 @@ export default function HomePage() {
 	);
 	const { data: limitsReport } = useQuery(usageLimitsQueryOptions({ api }));
 
-	const installedAgents = useMemo(
-		() =>
-			availableAgents.filter((agent) => agent.availability.is_available),
-		[availableAgents],
-	);
-
+	// Show every agent and let agentStatus() classify it — pre-filtering by
+	// is_available here would make the "missing" state unreachable on the grid.
 	const readyCount = useMemo(
-		() => installedAgents.filter((a) => agentStatus(a) === "ready").length,
-		[installedAgents],
+		() => availableAgents.filter((a) => agentStatus(a) === "ready").length,
+		[availableAgents],
 	);
 
 	const countsByAgent = useMemo(() => {
 		const map = new Map<string, { skills: number; mcps: number }>();
-		for (const agent of installedAgents) {
+		for (const agent of availableAgents) {
 			map.set(agent.id, {
 				skills: skills.filter((s) => !s.agent || s.agent === agent.id)
 					.length,
@@ -80,7 +76,7 @@ export default function HomePage() {
 			});
 		}
 		return map;
-	}, [installedAgents, skills, mcps]);
+	}, [availableAgents, skills, mcps]);
 
 	const usageByAgent = useMemo(() => {
 		const map = new Map<string, AgentUsageDto>();
@@ -106,7 +102,7 @@ export default function HomePage() {
 		const statusOrder = { ready: 0, missing: 1, disabled: 2 } as const;
 		const usageRank = (id: string) =>
 			id === "claude" ? 0 : id === "codex" ? 1 : 2;
-		return [...installedAgents].sort((a, b) => {
+		return [...availableAgents].sort((a, b) => {
 			const byUsage = usageRank(a.id) - usageRank(b.id);
 			if (byUsage !== 0) return byUsage;
 			const byStatus =
@@ -114,7 +110,7 @@ export default function HomePage() {
 			if (byStatus !== 0) return byStatus;
 			return a.display_name.localeCompare(b.display_name);
 		});
-	}, [installedAgents]);
+	}, [availableAgents]);
 
 	return (
 		<div className="h-full overflow-y-auto">
@@ -126,7 +122,7 @@ export default function HomePage() {
 					<p className="text-sm text-muted">
 						{t("homeSubtitle", {
 							ready: readyCount,
-							total: installedAgents.length,
+							total: availableAgents.length,
 						})}
 					</p>
 				</header>

--- a/crates/desktop/src/pages/market.tsx
+++ b/crates/desktop/src/pages/market.tsx
@@ -241,8 +241,18 @@ function McpMarketTab() {
 	);
 }
 
-function ClaudePluginsTab() {
-	return <PluginMarketContent enabled variant="page" />;
+function ClaudePluginsTab({
+	installScope,
+}: {
+	installScope: "global" | "project" | "local";
+}) {
+	return (
+		<PluginMarketContent
+			enabled
+			variant="page"
+			installScope={installScope}
+		/>
+	);
 }
 
 export default function MarketPage() {
@@ -253,6 +263,11 @@ export default function MarketPage() {
 	const activeTab: MarketTabId = isMarketTabId(tabParam)
 		? tabParam
 		: "skills-sh";
+	const [scopeParam] = useQueryState("scope", { defaultValue: "global" });
+	const pluginInstallScope: "global" | "project" | "local" =
+		scopeParam === "project" || scopeParam === "local"
+			? scopeParam
+			: "global";
 
 	return (
 		<div className="flex h-full flex-col">
@@ -339,7 +354,7 @@ export default function MarketPage() {
 				)}
 				{activeTab === "claude-plugins" && (
 					<Suspense fallback={<TabFallback />}>
-						<ClaudePluginsTab />
+						<ClaudePluginsTab installScope={pluginInstallScope} />
 					</Suspense>
 				)}
 				{activeTab === "github" && (

--- a/crates/desktop/src/pages/plugins/index.tsx
+++ b/crates/desktop/src/pages/plugins/index.tsx
@@ -225,7 +225,9 @@ export default function PluginsPage() {
 					onSearchChange={setSearchQuery}
 					onSelectionChange={handleSelectionChange}
 					onOpenMarket={() =>
-						setLocation("/market?tab=claude-plugins")
+						setLocation(
+							`/market?tab=claude-plugins&scope=${marketInstallScope}`,
+						)
 					}
 					onToggleMultiSelect={toggleMultiSelect}
 					onRefresh={() => void handleRefresh()}


### PR DESCRIPTION
## Summary

Follow-up fixes for the agent-hub-revamp work (merged via #282), surfaced by the CodeRabbit review on #287 and **verified against the actual code** before fixing. Two of CodeRabbit's reported issues turned out to be false positives and were left alone (see below).

Each fix is its own commit.

## Fixes

| commit | issue |
|---|---|
| `fix(desktop): preserve install scope when opening the plugin market` | **Major.** Opening the market from a project/local-scoped plugin dropped the scope, so it installed into `global`. Scope now travels via `?scope=`. |
| `fix(desktop): show missing and disabled agents on the home grid` | The `is_available` pre-filter made the "missing" status (and its sort bucket + card branch) unreachable. **Visible change:** the home grid now shows every agent, classified by `agentStatus()`. |
| `fix(desktop): exclude disabled agents from the resource filter` | Disabled agents were selectable filters but get filtered back out downstream → empty page. Now restricted to usable agents. |
| `fix(desktop): keep the query string on legacy search redirects` | `/library/search` & `/skills-sh/search` dropped `?q=` on redirect → empty Market view. |
| `perf(desktop): defer global-search list queries until search is used` | The sidebar mounts `GlobalSearch` everywhere, so the list queries fetched eagerly with an empty box. Now gated on a non-empty query. |
| `fix(i18n): localize the uncategorized plugin category` | `pluginCategories.other` was missing → raw "Other" in non-EN UI. |
| `fix(desktop): name the global-search results listbox` | The results listbox had no accessible name. |

## Verified false positives (left unchanged)

- **use-agent-filter sticky sync** — already mirrored URL→sticky in `app-sidebar.tsx` via an effect.
- **zh-Hant search label** — matches `en.ts` exactly (both intentionally omit sub-agents).

## Notes

- The home-grid change is user-visible (missing/disabled agents now appear). Easy to revert if the intent was install-only.
- The global-search a11y fix is **partial** — it only names the listbox. A full combobox pattern (`role=combobox`, `aria-activedescendant`, etc.) is better done by migrating `GlobalSearch` to HeroUI v3's `Autocomplete`/`ComboBox`, which is a separate task.

## Verification

- `bun run typecheck` ✓
- `eslint` on the changed files — no new issues
- `bun run build` ✓
- `prettier --check` ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scoped navigation for the Claude plugins marketplace (global, project, or local).
  * Added a new localized “Other” plugin category.
* **Bug Fixes**
  * Search redirects now preserve your current query.
  * Global search results are now labeled more clearly for accessibility.
* **Improvements**
  * Home page agent grid, counts, and sorting now reflect the full available agent set.
  * Global search now defers loading local results until you type (after trimming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->