### PR TITLE
chore(deps): migrate to posthog-rs 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +671,21 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2534,6 +2558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3819,7 +3849,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4698,6 +4728,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4999,6 +5041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5089,6 +5140,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5508,12 +5575,15 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.7.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fe987ce1bbf655e4a753d5a72d4729fe69fbfbf8d9ca6d1afd452d7117ea54"
+checksum = "78a4557dd7d995d8c86c74d9f0b5116db21ac3fd207413fbca820aaa6910b22b"
 dependencies = [
+ "backtrace",
  "chrono",
  "derive_builder",
+ "flate2",
+ "os_info",
  "regex",
  "reqwest",
  "semver",
@@ -5775,7 +5845,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5813,7 +5883,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6315,6 +6385,12 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -7955,7 +8031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/desktop/src-tauri/Cargo.toml
+++ b/crates/desktop/src-tauri/Cargo.toml
@@ -43,7 +43,7 @@ fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c
 log = { workspace = true }
 time = { version = "0.3", features = [ "formatting", "local-offset" ] }
 zip = { version = "8", default-features = false, features = [ "deflate" ] }
-posthog-rs = "0.7.0"
+posthog-rs = "0.15.1"
 uuid = { workspace = true }
 tauri-plugin-autostart = "2.5.1"
 sys-locale = "0.3.2"

--- a/crates/desktop/src-tauri/src/commands/posthog.rs
+++ b/crates/desktop/src-tauri/src/commands/posthog.rs
@@ -7,7 +7,6 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
-use std::time::Instant;
 use tauri::{AppHandle, Manager};
 use tokio::sync::OnceCell;
 use uuid::Uuid;
@@ -208,20 +207,10 @@ pub async fn posthog_capture(
 	apply_default_properties(&mut ev);
 	apply_properties(&mut ev, properties);
 
-	let event_label = event.clone();
-	tokio::spawn(async move {
-		let started = Instant::now();
-		match client.capture(ev).await {
-			Ok(()) => debug!(
-				"posthog: capture {event_label} sent in {:?}",
-				started.elapsed()
-			),
-			Err(error) => warn!(
-				"posthog: capture {event_label} failed after {:?}: {error}",
-				started.elapsed()
-			),
-		}
-	});
+	// posthog-rs 0.15 `capture` enqueues into the client's background sender and
+	// returns immediately — there is no per-event send result to await or log.
+	client.capture(ev);
+	debug!("posthog: capture {event} dispatched");
 	Ok(())
 }
 
@@ -266,20 +255,8 @@ pub async fn posthog_identify(
 		}
 	}
 
-	let id_label = distinct_id.clone();
-	tokio::spawn(async move {
-		let started = Instant::now();
-		match client.capture(ev).await {
-			Ok(()) => debug!(
-				"posthog: identify {id_label} sent in {:?}",
-				started.elapsed()
-			),
-			Err(error) => warn!(
-				"posthog: identify {id_label} failed after {:?}: {error}",
-				started.elapsed()
-			),
-		}
-	});
+	client.capture(ev);
+	debug!("posthog: identify {distinct_id} dispatched");
 	Ok(())
 }
 


### PR DESCRIPTION
Replaces #305 (stale + failing CI). posthog-rs 0.15 makes `Client::capture` a synchronous non-blocking enqueue (`transport.enqueue`) that no longer returns a `Result` — confirmed from the 0.15 source. The two capture sites drop their `tokio::spawn`/`.await`/match and just enqueue.

**Behavioral change (pre-approved):** per-event send confirmation/failure logging is gone; the client's background sender owns delivery (fire-and-forget). All other 0.15 API (`ClientOptionsBuilder`, `client()`, `Event`, `insert_prop`) is unchanged.

Verified: `cargo clippy -p aghub --all-targets -- -D warnings` clean.