### PR TITLE
feat(desktop): move market tabs into sidebar as sub-nav

### DIFF
--- a/crates/desktop/src/components/app-sidebar.tsx
+++ b/crates/desktop/src/components/app-sidebar.tsx
@@ -15,6 +15,7 @@ import {
 	setStickyAgentFilter,
 	useStickyAgentFilter,
 } from "../hooks/use-sticky-agent-filter";
+import { MARKET_TABS, resolveMarketTab } from "../lib/market-tabs";
 import { isSidebarHrefActive } from "../lib/sidebar-navigation";
 import { cn } from "../lib/utils";
 import { GlobalSearch } from "./global-search";
@@ -23,6 +24,26 @@ import { ProjectList } from "./project-list";
 function navItemClasses(isActive: boolean) {
 	return cn(
 		"flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
+		isActive
+			? "bg-surface font-medium text-foreground"
+			: "text-muted hover:bg-surface-secondary hover:text-foreground",
+	);
+}
+
+// The market parent is a group header: it stays in the market section while a
+// child tab carries the filled active state, so it never fills itself.
+function marketParentClasses(isActive: boolean) {
+	return cn(
+		"flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
+		isActive
+			? "font-medium text-foreground"
+			: "text-muted hover:bg-surface-secondary hover:text-foreground",
+	);
+}
+
+function marketSubItemClasses(isActive: boolean) {
+	return cn(
+		"flex items-center gap-2.5 rounded-md py-1.5 pr-2.5 pl-9 text-sm transition-colors",
 		isActive
 			? "bg-surface font-medium text-foreground"
 			: "text-muted hover:bg-surface-secondary hover:text-foreground",
@@ -76,6 +97,10 @@ export function AppSidebar() {
 
 	const homeItem = visibleSidebarItems.find((item) => item.id === "home");
 	const marketItem = visibleSidebarItems.find((item) => item.id === "market");
+	const onMarketPage = pathname === "/market";
+	const activeMarketTab = resolveMarketTab(
+		new URLSearchParams(search).get("tab"),
+	);
 
 	return (
 		<Surface
@@ -105,20 +130,37 @@ export function AppSidebar() {
 							</Link>
 						)}
 						{marketItem && (
-							<Link
-								key={marketItem.id}
-								href={marketItem.href}
-								data-tour={marketItem.tour}
-								className={navItemClasses(
-									isSidebarHrefActive(
-										pathname,
-										marketItem.href,
-									),
-								)}
-							>
-								<marketItem.icon className="size-4" />
-								<span>{t(marketItem.labelKey)}</span>
-							</Link>
+							<div className="flex flex-col gap-0.5">
+								<Link
+									key={marketItem.id}
+									href={marketItem.href}
+									data-tour={marketItem.tour}
+									className={marketParentClasses(
+										isSidebarHrefActive(
+											pathname,
+											marketItem.href,
+										),
+									)}
+								>
+									<marketItem.icon className="size-4" />
+									<span>{t(marketItem.labelKey)}</span>
+								</Link>
+								{MARKET_TABS.map((tab) => (
+									<Link
+										key={tab.id}
+										href={`/market?tab=${tab.id}`}
+										className={marketSubItemClasses(
+											onMarketPage &&
+												activeMarketTab === tab.id,
+										)}
+									>
+										<tab.icon className="size-4 shrink-0" />
+										<span className="truncate">
+											{t(tab.labelKey)}
+										</span>
+									</Link>
+								))}
+							</div>
 						)}
 					</nav>
 

--- a/crates/desktop/src/lib/market-tabs.ts
+++ b/crates/desktop/src/lib/market-tabs.ts
@@ -1,0 +1,43 @@
+import {
+	CodeBracketIcon,
+	PuzzlePieceIcon,
+	ServerIcon,
+	SparklesIcon,
+} from "@heroicons/react/24/solid";
+import type { ComponentType, SVGProps } from "react";
+
+export const MARKET_TAB_IDS = [
+	"skills-sh",
+	"mcp",
+	"claude-plugins",
+	"github",
+] as const;
+
+export type MarketTabId = (typeof MARKET_TAB_IDS)[number];
+
+export const DEFAULT_MARKET_TAB: MarketTabId = "skills-sh";
+
+export interface MarketTabDefinition {
+	id: MarketTabId;
+	labelKey: string;
+	icon: ComponentType<SVGProps<SVGSVGElement>>;
+}
+
+export const MARKET_TABS: MarketTabDefinition[] = [
+	{ id: "skills-sh", labelKey: "marketTabSkillsSh", icon: SparklesIcon },
+	{ id: "mcp", labelKey: "marketTabMcp", icon: ServerIcon },
+	{
+		id: "claude-plugins",
+		labelKey: "marketTabClaudePlugins",
+		icon: PuzzlePieceIcon,
+	},
+	{ id: "github", labelKey: "marketTabGithub", icon: CodeBracketIcon },
+];
+
+export function isMarketTabId(value: string | null): value is MarketTabId {
+	return MARKET_TAB_IDS.includes(value as MarketTabId);
+}
+
+export function resolveMarketTab(value: string | null): MarketTabId {
+	return isMarketTabId(value) ? value : DEFAULT_MARKET_TAB;
+}

--- a/crates/desktop/src/pages/market.tsx
+++ b/crates/desktop/src/pages/market.tsx
@@ -1,15 +1,14 @@
 import {
 	BuildingStorefrontIcon,
-	CodeBracketIcon,
-	PuzzlePieceIcon,
 	ServerIcon,
 	SparklesIcon,
 } from "@heroicons/react/24/solid";
-import { Button, Card, Spinner, Surface, Tabs } from "@heroui/react";
+import { Button, Card, Spinner } from "@heroui/react";
 import { useQueryState } from "nuqs";
 import { lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "wouter";
+import { resolveMarketTab } from "../lib/market-tabs";
 import { cn } from "../lib/utils";
 import SkillsShPage from "./skills-sh";
 
@@ -31,14 +30,6 @@ function TabFallback() {
 		</div>
 	);
 }
-
-const MARKET_TAB_IDS = [
-	"skills-sh",
-	"mcp",
-	"claude-plugins",
-	"github",
-] as const;
-type MarketTabId = (typeof MARKET_TAB_IDS)[number];
 
 interface McpMarketEntry {
 	id: string;
@@ -158,10 +149,6 @@ const MOCK_MCP_SERVERS: McpMarketEntry[] = [
 	},
 ];
 
-function isMarketTabId(value: string | null): value is MarketTabId {
-	return MARKET_TAB_IDS.includes(value as MarketTabId);
-}
-
 function McpMarketTab() {
 	const { t } = useTranslation();
 	const [, setLocation] = useLocation();
@@ -247,12 +234,8 @@ function ClaudePluginsTab() {
 
 export default function MarketPage() {
 	const { t } = useTranslation();
-	const [tabParam, setTabParam] = useQueryState("tab", {
-		defaultValue: "skills-sh",
-	});
-	const activeTab: MarketTabId = isMarketTabId(tabParam)
-		? tabParam
-		: "skills-sh";
+	const [tabParam] = useQueryState("tab");
+	const activeTab = resolveMarketTab(tabParam);
 
 	return (
 		<div className="flex h-full flex-col">
@@ -269,66 +252,6 @@ export default function MarketPage() {
 					</p>
 				</div>
 			</header>
-
-			<Surface
-				variant="secondary"
-				className="border-b border-border px-4 py-2"
-			>
-				<Tabs
-					selectedKey={activeTab}
-					onSelectionChange={(key) =>
-						setTabParam(String(key) as MarketTabId)
-					}
-				>
-					<Tabs.ListContainer>
-						<Tabs.List
-							aria-label={t("marketSections")}
-							className="inline-flex w-auto"
-						>
-							<Tabs.Tab
-								id="skills-sh"
-								className="px-4 whitespace-nowrap"
-							>
-								<span className="flex items-center gap-1.5">
-									<SparklesIcon className="size-3.5" />
-									{t("marketTabSkillsSh")}
-								</span>
-								<Tabs.Indicator />
-							</Tabs.Tab>
-							<Tabs.Tab
-								id="mcp"
-								className="px-4 whitespace-nowrap"
-							>
-								<span className="flex items-center gap-1.5">
-									<ServerIcon className="size-3.5" />
-									{t("marketTabMcp")}
-								</span>
-								<Tabs.Indicator />
-							</Tabs.Tab>
-							<Tabs.Tab
-								id="claude-plugins"
-								className="px-4 whitespace-nowrap"
-							>
-								<span className="flex items-center gap-1.5">
-									<PuzzlePieceIcon className="size-3.5" />
-									{t("marketTabClaudePlugins")}
-								</span>
-								<Tabs.Indicator />
-							</Tabs.Tab>
-							<Tabs.Tab
-								id="github"
-								className="px-4 whitespace-nowrap"
-							>
-								<span className="flex items-center gap-1.5">
-									<CodeBracketIcon className="size-3.5" />
-									{t("marketTabGithub")}
-								</span>
-								<Tabs.Indicator />
-							</Tabs.Tab>
-						</Tabs.List>
-					</Tabs.ListContainer>
-				</Tabs>
-			</Surface>
 
 			<div className="min-h-0 flex-1 overflow-y-auto">
 				{activeTab === "skills-sh" && <SkillsShPage />}


### PR DESCRIPTION
## Summary

- Move the market page's four tabs (Skills.sh, MCP, Claude Code plugins, GitHub import) into the sidebar as sub-nav items under the Market entry.
- Extract shared tab definitions (id, label key, icon) into `crates/desktop/src/lib/market-tabs.ts` so the market page and sidebar share one source of truth.
- Remove the in-page tab bar; the market page still switches content by the `?tab=` query param, and the existing `/market?tab=<id>` deep link (already used by the plugins page) keeps working.

## Active state

- Sub-items highlight by the current `?tab=` (defaults to `skills-sh`) and only on `/market`, so `/market/search` and other routes never mis-highlight.
- The Market parent acts as a group header: foreground emphasis without a filled background, letting the active child carry the fill instead of both rows filling at once.

## Notes

- Sub-items are always visible, matching the old always-visible tab bar. Switching to "expand only on `/market`" is a one-line change gated on `onMarketPage`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (changed files clean)
- [x] `bun run build`
- [ ] `bun run tauri dev`: open the sidebar, confirm the four sub-items render under Market and the active one highlights as you switch sections / navigate to `/market?tab=<id>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Market section now shows a clearer parent item with dedicated sub-tabs for each market view.
  * Market tab selection is now reflected directly in the URL, making navigation and sharing easier.

* **Bug Fixes**
  * Improved tab handling so the correct market view stays selected when returning to the Market page or using links.
  * Added safer fallback behavior when an invalid or missing tab value is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->