### PR TITLE
fix(desktop): count only files in skill tree stats

### DIFF
--- a/crates/desktop/src/components/skill-detail-helpers.ts
+++ b/crates/desktop/src/components/skill-detail-helpers.ts
@@ -44,13 +44,11 @@ export function hasSupplementarySkillFiles(
 	});
 }
 
-export function countTreeNodes(node: SkillTreeNodeResponse): number {
-	return (
-		getNodeChildren(node).length +
-		getNodeChildren(node).reduce(
-			(total, child) => total + countTreeNodes(child),
-			0,
-		)
+export function countTreeFiles(node: SkillTreeNodeResponse): number {
+	return getNodeChildren(node).reduce(
+		(total, child) =>
+			total + (child.kind === "file" ? 1 : 0) + countTreeFiles(child),
+		0,
 	);
 }
 

--- a/crates/desktop/src/components/skill-detail.tsx
+++ b/crates/desktop/src/components/skill-detail.tsx
@@ -39,7 +39,7 @@ import {
 } from "./skill-detail-dialogs";
 import {
 	buildLocationGroups,
-	countTreeNodes,
+	countTreeFiles,
 	hasSupplementarySkillFiles,
 	type LocationGroup,
 	type SkillGroup,
@@ -204,7 +204,7 @@ export function SkillDetail({ group, projectPath }: SkillDetailProps) {
 	const hasMoreLocations = allLocationGroups.length > 3;
 	const hiddenLocationCount = allLocationGroups.length - 2;
 	const resourceCount = useMemo(
-		() => (skillTree ? countTreeNodes(skillTree) : 0),
+		() => (skillTree ? countTreeFiles(skillTree) : 0),
 		[skillTree],
 	);
 	const hasSupplementaryFiles = useMemo(


### PR DESCRIPTION
## 问题

Skill 详情页「技能文件」面板的数量统计把文件夹和文件混在一起计数。

## 修复

`countTreeNodes` 对每个子节点无条件 `+1`；改为只统计 `kind === "file"` 的节点，并更名为 `countTreeFiles` 对齐语义。调用方 `skill-detail.tsx` 的 `resourceCount` 同步。

Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the skill details view to show the number of files instead of counting every item in the tree, making the displayed total more accurate.
  * Adjusted the “skill files” accordion description to match the new file-based count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->