### PR TITLE
refactor(desktop): name store migrations by domain

### DIFF
--- a/crates/desktop/src/lib/store/migrations/index.test.ts
+++ b/crates/desktop/src/lib/store/migrations/index.test.ts
@@ -1,0 +1,65 @@
+import type { Store } from "@tauri-apps/plugin-store";
+import { describe, expect, it } from "vitest";
+import { CURRENT_VERSION } from "../types";
+import { migrate } from ".";
+
+function memoryStore(entries: Array<[string, unknown]> = []) {
+	const values = new Map(entries);
+	const writes: string[] = [];
+	let saveCount = 0;
+	const store = {
+		get: async <T>(key: string) => values.get(key) as T | undefined,
+		set: async (key: string, value: unknown) => {
+			writes.push(key);
+			values.set(key, value);
+		},
+		save: async () => {
+			saveCount += 1;
+		},
+	} satisfies Pick<Store, "get" | "set" | "save">;
+
+	return {
+		store: store as Store,
+		values,
+		writes,
+		getSaveCount: () => saveCount,
+	};
+}
+
+describe("migrate", () => {
+	it("runs pending migrations in schema order", async () => {
+		const { store, values, writes, getSaveCount } = memoryStore();
+
+		await migrate(store);
+
+		expect(writes).toEqual([
+			"projects",
+			"disabledAgents",
+			"integrationPreferences",
+			"starredSkills",
+			"starredMcps",
+			"onboardingProgress",
+			"sidebarItems",
+			"autoCheckUpdates",
+			"sidebarItems",
+			"updateChannel",
+			"acknowledgedSkillAssessments",
+			"skillAuditEnabled",
+			"version",
+		]);
+		expect(values.get("version")).toBe(CURRENT_VERSION);
+		expect(getSaveCount()).toBe(1);
+	});
+
+	it("is idempotent after reaching the current version", async () => {
+		const { store, writes, getSaveCount } = memoryStore();
+
+		await migrate(store);
+		const firstRunWrites = [...writes];
+
+		await migrate(store);
+
+		expect(writes).toEqual(firstRunWrites);
+		expect(getSaveCount()).toBe(1);
+	});
+});

--- a/crates/desktop/src/lib/store/migrations/index.ts
+++ b/crates/desktop/src/lib/store/migrations/index.ts
@@ -1,15 +1,15 @@
 import type { Store } from "@tauri-apps/plugin-store";
 import { CURRENT_VERSION } from "../types";
-import { migrateV0ToV1 } from "./v0-to-v1";
-import { migrateV1ToV2 } from "./v1-to-v2";
-import { migrateV2ToV3 } from "./v2-to-v3";
-import { migrateV3ToV4 } from "./v3-to-v4";
-import { migrateV4ToV5 } from "./v4-to-v5";
-import { migrateV5ToV6 } from "./v5-to-v6";
-import { migrateV6ToV7 } from "./v6-to-v7";
-import { migrateV7ToV8 } from "./v7-to-v8";
-import { migrateV8ToV9 } from "./v8-to-v9";
-import { migrateV9ToV10 } from "./v9-to-v10";
+import { initializeAutoCheckUpdates } from "./initialize-auto-check-updates";
+import { initializeDisabledAgents } from "./initialize-disabled-agents";
+import { initializeIntegrationPreferences } from "./initialize-integration-preferences";
+import { initializeOnboardingProgress } from "./initialize-onboarding-progress";
+import { initializeProjects } from "./initialize-projects";
+import { initializeSidebarItems } from "./initialize-sidebar-items";
+import { initializeSkillAuditPreferences } from "./initialize-skill-audit-preferences";
+import { initializeStarredResources } from "./initialize-starred-resources";
+import { normalizeUpdateChannel } from "./normalize-update-channel";
+import { resetSidebarItems } from "./reset-sidebar-items";
 
 export async function migrate(store: Store): Promise<void> {
 	const version = (await store.get<number>("version")) ?? 0;
@@ -17,43 +17,43 @@ export async function migrate(store: Store): Promise<void> {
 	if (version === CURRENT_VERSION) return;
 
 	if (version < 1) {
-		await migrateV0ToV1(store);
+		await initializeProjects(store);
 	}
 
 	if (version < 2) {
-		await migrateV1ToV2(store);
+		await initializeDisabledAgents(store);
 	}
 
 	if (version < 3) {
-		await migrateV2ToV3(store);
+		await initializeIntegrationPreferences(store);
 	}
 
 	if (version < 4) {
-		await migrateV3ToV4(store);
+		await initializeStarredResources(store);
 	}
 
 	if (version < 5) {
-		await migrateV4ToV5(store);
+		await initializeOnboardingProgress(store);
 	}
 
 	if (version < 6) {
-		await migrateV5ToV6(store);
+		await initializeSidebarItems(store);
 	}
 
 	if (version < 7) {
-		await migrateV6ToV7(store);
+		await initializeAutoCheckUpdates(store);
 	}
 
 	if (version < 8) {
-		await migrateV7ToV8(store);
+		await resetSidebarItems(store);
 	}
 
 	if (version < 9) {
-		await migrateV8ToV9(store);
+		await normalizeUpdateChannel(store);
 	}
 
 	if (version < 10) {
-		await migrateV9ToV10(store);
+		await initializeSkillAuditPreferences(store);
 	}
 
 	await store.set("version", CURRENT_VERSION);

--- a/crates/desktop/src/lib/store/migrations/initialize-auto-check-updates.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-auto-check-updates.ts
@@ -1,5 +1,5 @@
 import type { Store } from "@tauri-apps/plugin-store";
 
-export async function migrateV6ToV7(store: Store): Promise<void> {
+export async function initializeAutoCheckUpdates(store: Store): Promise<void> {
 	await store.set("autoCheckUpdates", true);
 }

--- a/crates/desktop/src/lib/store/migrations/initialize-disabled-agents.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-disabled-agents.ts
@@ -1,5 +1,5 @@
 import type { Store } from "@tauri-apps/plugin-store";
 
-export async function migrateV1ToV2(store: Store): Promise<void> {
+export async function initializeDisabledAgents(store: Store): Promise<void> {
 	await store.set("disabledAgents", []);
 }

--- a/crates/desktop/src/lib/store/migrations/initialize-integration-preferences.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-integration-preferences.ts
@@ -1,5 +1,7 @@
 import type { Store } from "@tauri-apps/plugin-store";
 
-export async function migrateV2ToV3(store: Store): Promise<void> {
+export async function initializeIntegrationPreferences(
+	store: Store,
+): Promise<void> {
 	await store.set("integrationPreferences", {});
 }

--- a/crates/desktop/src/lib/store/migrations/initialize-onboarding-progress.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-onboarding-progress.ts
@@ -1,6 +1,8 @@
 import type { Store } from "@tauri-apps/plugin-store";
 import { DEFAULT_ONBOARDING_PROGRESS } from "../types";
 
-export async function migrateV4ToV5(store: Store): Promise<void> {
+export async function initializeOnboardingProgress(
+	store: Store,
+): Promise<void> {
 	await store.set("onboardingProgress", DEFAULT_ONBOARDING_PROGRESS);
 }

--- a/crates/desktop/src/lib/store/migrations/initialize-projects.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-projects.ts
@@ -1,5 +1,5 @@
 import type { Store } from "@tauri-apps/plugin-store";
 
-export async function migrateV0ToV1(store: Store): Promise<void> {
+export async function initializeProjects(store: Store): Promise<void> {
 	await store.set("projects", []);
 }

--- a/crates/desktop/src/lib/store/migrations/initialize-sidebar-items.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-sidebar-items.ts
@@ -1,6 +1,6 @@
 import type { Store } from "@tauri-apps/plugin-store";
 import { DEFAULT_SIDEBAR_ITEMS } from "../types";
 
-export async function migrateV7ToV8(store: Store): Promise<void> {
+export async function initializeSidebarItems(store: Store): Promise<void> {
 	await store.set("sidebarItems", DEFAULT_SIDEBAR_ITEMS);
 }

--- a/crates/desktop/src/lib/store/migrations/initialize-skill-audit-preferences.test.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-skill-audit-preferences.test.ts
@@ -1,6 +1,6 @@
 import type { Store } from "@tauri-apps/plugin-store";
 import { describe, expect, it } from "vitest";
-import { migrateV9ToV10 } from "./v9-to-v10";
+import { initializeSkillAuditPreferences } from "./initialize-skill-audit-preferences";
 
 function memoryStore(entries: Array<[string, unknown]> = []) {
 	const values = new Map(entries);
@@ -13,11 +13,11 @@ function memoryStore(entries: Array<[string, unknown]> = []) {
 	return { store, values };
 }
 
-describe("migrateV9ToV10", () => {
+describe("initializeSkillAuditPreferences", () => {
 	it("initializes skill audit preferences", async () => {
 		const { store, values } = memoryStore();
 
-		await migrateV9ToV10(store);
+		await initializeSkillAuditPreferences(store);
 
 		expect(values.get("acknowledgedSkillAssessments")).toEqual([]);
 		expect(values.get("skillAuditEnabled")).toBe(true);
@@ -32,7 +32,7 @@ describe("migrateV9ToV10", () => {
 			["skillAuditEnabled", false],
 		]);
 
-		await migrateV9ToV10(store);
+		await initializeSkillAuditPreferences(store);
 
 		expect(values.get("acknowledgedSkillAssessments")).toBe(assessments);
 		expect(values.get("skillAuditEnabled")).toBe(false);

--- a/crates/desktop/src/lib/store/migrations/initialize-skill-audit-preferences.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-skill-audit-preferences.ts
@@ -2,7 +2,9 @@ import type { Store } from "@tauri-apps/plugin-store";
 
 type MigrationStore = Pick<Store, "get" | "set">;
 
-export async function migrateV9ToV10(store: MigrationStore): Promise<void> {
+export async function initializeSkillAuditPreferences(
+	store: MigrationStore,
+): Promise<void> {
 	const assessments = await store.get<unknown>(
 		"acknowledgedSkillAssessments",
 	);

--- a/crates/desktop/src/lib/store/migrations/initialize-starred-resources.ts
+++ b/crates/desktop/src/lib/store/migrations/initialize-starred-resources.ts
@@ -1,6 +1,6 @@
 import type { Store } from "@tauri-apps/plugin-store";
 
-export async function migrateV3ToV4(store: Store): Promise<void> {
+export async function initializeStarredResources(store: Store): Promise<void> {
 	await store.set("starredSkills", []);
 	await store.set("starredMcps", []);
 }

--- a/crates/desktop/src/lib/store/migrations/normalize-update-channel.ts
+++ b/crates/desktop/src/lib/store/migrations/normalize-update-channel.ts
@@ -1,6 +1,6 @@
 import type { Store } from "@tauri-apps/plugin-store";
 
-export async function migrateV8ToV9(store: Store): Promise<void> {
+export async function normalizeUpdateChannel(store: Store): Promise<void> {
 	const channel = await store.get<string>("updateChannel");
 	if (channel !== "stable" && channel !== "beta") {
 		await store.set("updateChannel", "stable");

--- a/crates/desktop/src/lib/store/migrations/reset-sidebar-items.ts
+++ b/crates/desktop/src/lib/store/migrations/reset-sidebar-items.ts
@@ -1,6 +1,6 @@
 import type { Store } from "@tauri-apps/plugin-store";
 import { DEFAULT_SIDEBAR_ITEMS } from "../types";
 
-export async function migrateV5ToV6(store: Store): Promise<void> {
+export async function resetSidebarItems(store: Store): Promise<void> {
 	await store.set("sidebarItems", DEFAULT_SIDEBAR_ITEMS);
 }


### PR DESCRIPTION
## Summary

- rename Store migration modules and functions after the data they change
- keep the integer schema version and every existing version guard
- add runner coverage for migration order and repeat execution

## Historical basis

Commit `03c992d` split the original `store.ts` into domain modules and `migrations/`. At that point the Store already had `CURRENT_VERSION = 5` and sequential `version < N` guards; the split moved that behavior into one file per version and retained `store.ts` as a compatibility re-export.

The numeric filename later became ambiguous in repository history:

- `39dcf51f` added `v8-to-v9.ts` for resource group keys.
- `879a436b` removed that migration and returned `CURRENT_VERSION` from 9 to 8 because the group readers already supplied defaults.
- `51ceba14` created a new `v8-to-v9.ts` for the unrelated update channel preference.

The same path therefore described two different data domains at different times. The version slot is useful to the dispatcher, but it does not identify migration intent during review.

## Why the version mechanism stays

Several earlier migrations assign default values directly. Running them on every startup would overwrite persisted project, agent, favorites, onboarding, sidebar, or update preferences. The stored integer version prevents those completed steps from running again and lets an older Store execute all pending steps in order.

This change keeps `CURRENT_VERSION = 10`, all `version < N` conditions, and the final version write/save. It only replaces numeric module/function names with domain actions such as `initializeProjects`, `resetSidebarItems`, and `normalizeUpdateChannel`.

## Compatibility

- no persisted key or value changed
- no migration function body changed
- no schema version changed
- no execution guard or ordering changed
- no Store data format changed

The new runner test records the write sequence from version 0 through version 10 and verifies that a second run performs no writes or save after the current version is stored.

## Validation

- `bun run test:unit`: 10 files, 79 tests passed
- `bun run typecheck`
- `bun run format:check`
- `just fmt`
- `just lint`: Clippy passed; ESLint reported 0 errors and 2 pre-existing set-state-in-effect warnings outside this diff
- `git diff --check`
