### PR TITLE
docs(brand): standardize lowercase aghub branding

### DIFF
--- a/.agents/skills/project-form-patterns/SKILL.md
+++ b/.agents/skills/project-form-patterns/SKILL.md
@@ -3,7 +3,7 @@ name: project-form-patterns
 description: Form implementation guidance for the aghub desktop app. Use when building or refactoring forms in `crates/desktop/src`, especially HeroUI v3 + React forms, RHF integration, validation, custom editors, and error presentation. Triggers: MCP forms, settings dialogs, create/edit panels, `TextField`, `FieldError`, `Select`, `react-hook-form`, key-value editors, validation behavior.
 ---
 
-# AGHub Form Patterns
+# aghub Form Patterns
 
 Follow these rules when building forms in this project.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGHUB KNOWLEDGE BASE
+# aghub KNOWLEDGE BASE
 
 **Project**: aghub — AI coding agent configuration management tool\
 **Stack**: Rust workspace + Tauri v2 desktop + React/TypeScript\
@@ -6,7 +6,7 @@
 
 ## OVERVIEW
 
-Aghub manages AGENTS.md, MCP configs, and skills for 25+ AI assistants through a unified CLI (`aghub-cli`) and desktop app. Stateless design—reads actual config files, tracks capability sources, enforces explicit opt-in for changes.
+aghub manages AGENTS.md, MCP configs, and skills for 25+ AI assistants through a unified CLI (`aghub-cli`) and desktop app. Stateless design—reads actual config files, tracks capability sources, enforces explicit opt-in for changes.
 
 ## STRUCTURE
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Aghub is a CLI tool (`aghub-cli`) for managing AI coding agent configurations. It supports 22 agents (Claude, OpenCode, Cursor, Windsurf, Copilot, RooCode, Cline, Gemini, Codex, Zed, Warp, and more), handling MCP servers and skills through a unified interface. Full agent list: `crates/core/src/models.rs` or `aghub-cli --help`.
+aghub is a CLI tool (`aghub-cli`) for managing AI coding agent configurations. It supports 22 agents (Claude, OpenCode, Cursor, Windsurf, Copilot, RooCode, Cline, Gemini, Codex, Zed, Warp, and more), handling MCP servers and skills through a unified interface. Full agent list: `crates/core/src/models.rs` or `aghub-cli --help`.
 
 ## Common Commands
 

--- a/README.CN.md
+++ b/README.CN.md
@@ -11,7 +11,7 @@
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri%202-orange.svg)](https://tauri.app/)
 [![License](https://img.shields.io/github/license/akarachen/aghub)](https://github.com/akarachen/aghub/blob/main/LICENSE)
 
-<a href="https://www.producthunt.com/products/aghub/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-aghub" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1193657&theme=light" alt="AGHub - The&#32;hub&#32;for&#32;every&#32;AI&#32;agent&#32;that&#32;isn&#39;t&#32;slop&#46; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+<a href="https://www.producthunt.com/products/aghub/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-aghub" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1193657&theme=light" alt="aghub - The&#32;hub&#32;for&#32;every&#32;AI&#32;agent&#32;that&#32;isn&#39;t&#32;slop&#46; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 [English Version](./README.md)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri%202-orange.svg)](https://tauri.app/)
 [![License](https://img.shields.io/github/license/akarachen/aghub)](https://github.com/akarachen/aghub/blob/main/LICENSE)
 
-<a href="https://www.producthunt.com/products/aghub/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-aghub" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1193657&theme=light" alt="AGHub - The&#32;hub&#32;for&#32;every&#32;AI&#32;agent&#32;that&#32;isn&#39;t&#32;slop&#46; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+<a href="https://www.producthunt.com/products/aghub/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-aghub" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1193657&theme=light" alt="aghub - The&#32;hub&#32;for&#32;every&#32;AI&#32;agent&#32;that&#32;isn&#39;t&#32;slop&#46; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 [中文版本](./README.CN.md)
 

--- a/crates/cc-plugins/src/lib.rs
+++ b/crates/cc-plugins/src/lib.rs
@@ -1,4 +1,4 @@
-//! Aghub Plugin System
+//! aghub Plugin System
 //!
 //! Provides support for managing Claude Code Plugin System (v2)
 

--- a/crates/desktop/scripts/release-notes.test.ts
+++ b/crates/desktop/scripts/release-notes.test.ts
@@ -9,9 +9,9 @@ const manifestSource = `
 version: 1.9.0-beta.1
 channel: beta
 title:
-  en: Aghub 1.9 beta
-  zh-Hans: Aghub 1.9 测试版
-  zh-Hant: Aghub 1.9 測試版
+  en: aghub 1.9 beta
+  zh-Hans: aghub 1.9 测试版
+  zh-Hant: aghub 1.9 測試版
 summary:
   en: Preview the latest desktop changes.
   zh-Hans: 提前体验最新桌面端改动。
@@ -44,7 +44,7 @@ describe("release notes manifest", () => {
 
 	it("rejects a missing locale before publishing", () => {
 		const missingTraditionalChinese = manifestSource.replace(
-			"  zh-Hant: Aghub 1.9 測試版\n",
+			"  zh-Hant: aghub 1.9 測試版\n",
 			"",
 		);
 

--- a/crates/desktop/src/lib/locales/en.ts
+++ b/crates/desktop/src/lib/locales/en.ts
@@ -102,7 +102,7 @@ export default {
 	rulesSaved: "Rule file saved",
 	rulesSaveFailed: "Failed to save rule file",
 	rulesChangedOnDisk:
-		"This file changed outside AGHub. Reload it or overwrite it with your draft.",
+		"This file changed outside aghub. Reload it or overwrite it with your draft.",
 	rulesReloadFromDisk: "Reload from disk",
 	rulesOverwriteDisk: "Overwrite disk file",
 	rulesVersionHistory: "Version history",

--- a/crates/desktop/src/lib/locales/zh-Hans.ts
+++ b/crates/desktop/src/lib/locales/zh-Hans.ts
@@ -98,7 +98,7 @@ export default {
 	rulesSaved: "规则文件已保存",
 	rulesSaveFailed: "保存规则文件失败",
 	rulesChangedOnDisk:
-		"该文件已在 AGHub 外部更改。请重新载入磁盘内容，或用当前草稿覆盖。",
+		"该文件已在 aghub 外部更改。请重新载入磁盘内容，或用当前草稿覆盖。",
 	rulesReloadFromDisk: "重新载入磁盘内容",
 	rulesOverwriteDisk: "用草稿覆盖",
 	rulesVersionHistory: "版本记录",

--- a/crates/desktop/src/lib/locales/zh-Hant.ts
+++ b/crates/desktop/src/lib/locales/zh-Hant.ts
@@ -98,7 +98,7 @@ export default {
 	rulesSaved: "規則檔案已儲存",
 	rulesSaveFailed: "儲存規則檔案失敗",
 	rulesChangedOnDisk:
-		"該檔案已在 AGHub 外部更改。請重新載入磁碟內容，或用目前草稿覆蓋。",
+		"該檔案已在 aghub 外部更改。請重新載入磁碟內容，或用目前草稿覆蓋。",
 	rulesReloadFromDisk: "重新載入磁碟內容",
 	rulesOverwriteDisk: "用草稿覆蓋",
 	rulesVersionHistory: "版本記錄",


### PR DESCRIPTION
## 修改内容

- 将 #422 中的 b93b22cd 品牌文案提交独立归入本 PR。
- 统一桌面端三语言文案、README 的图片替代文本、仓库说明、表单 Skill 标题、Rust 文档和发布说明测试样例中的产品名为小写 aghub。
- 保留 Homebrew 约定要求的 AghubCli Ruby 类名、环境变量和其他兼容性技术标识。
- 不改第三方服务内容、历史 Changelog 或已发布 Release；GitHub 仓库简介当前没有大写产品名，无须修改。

## 验证

- 发布说明测试：7 passed。
- Desktop typecheck、修改文件格式检查和 git diff --check 通过。
- 维护中的非历史文本检索，仅保留 AghubCli 技术类名。

Closes #435